### PR TITLE
Added missing recipes and recipe fixes

### DIFF
--- a/src/main/java/dev/emi/emi/VanillaPlugin.java
+++ b/src/main/java/dev/emi/emi/VanillaPlugin.java
@@ -49,11 +49,14 @@ import dev.emi.emi.recipe.EmiSmithingRecipe;
 import dev.emi.emi.recipe.EmiStonecuttingRecipe;
 import dev.emi.emi.recipe.EmiTagRecipe;
 import dev.emi.emi.recipe.special.EmiArmorDyeRecipe;
+import dev.emi.emi.recipe.special.EmiBannerDuplicateRecipe;
 import dev.emi.emi.recipe.special.EmiBannerShieldRecipe;
 import dev.emi.emi.recipe.special.EmiBookCloningRecipe;
 import dev.emi.emi.recipe.special.EmiFireworkRocketRecipe;
 import dev.emi.emi.recipe.special.EmiFireworkStarFadeRecipe;
 import dev.emi.emi.recipe.special.EmiFireworkStarRecipe;
+import dev.emi.emi.recipe.special.EmiMapCloningRecipe;
+import dev.emi.emi.recipe.special.EmiRepairItemRecipe;
 import dev.emi.emi.recipe.special.EmiSuspiciousStewRecipe;
 import dev.emi.emi.screen.RecipeScreen;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
@@ -83,6 +86,7 @@ import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionUtil;
 import net.minecraft.potion.Potions;
 import net.minecraft.recipe.ArmorDyeRecipe;
+import net.minecraft.recipe.BannerDuplicateRecipe;
 import net.minecraft.recipe.BlastingRecipe;
 import net.minecraft.recipe.BookCloningRecipe;
 import net.minecraft.recipe.BrewingRecipeRegistry;
@@ -92,8 +96,11 @@ import net.minecraft.recipe.FireworkRocketRecipe;
 import net.minecraft.recipe.FireworkStarFadeRecipe;
 import net.minecraft.recipe.FireworkStarRecipe;
 import net.minecraft.recipe.Ingredient;
+import net.minecraft.recipe.MapCloningRecipe;
+import net.minecraft.recipe.MapExtendingRecipe;
 import net.minecraft.recipe.Recipe;
 import net.minecraft.recipe.RecipeType;
+import net.minecraft.recipe.RepairItemRecipe;
 import net.minecraft.recipe.ShapedRecipe;
 import net.minecraft.recipe.ShapelessRecipe;
 import net.minecraft.recipe.ShieldDecorationRecipe;
@@ -230,7 +237,16 @@ public class VanillaPlugin implements EmiPlugin {
 		registry.setDefaultComparison(Items.ENCHANTED_BOOK, compareNbt);
 
 		for (CraftingRecipe recipe : registry.getRecipeManager().listAllOfType(RecipeType.CRAFTING)) {
-			if (recipe instanceof ShapedRecipe shaped && recipe.fits(3, 3)) {
+			if (recipe instanceof MapExtendingRecipe map) {
+				EmiStack paper = EmiStack.of(Items.PAPER);
+				addRecipeSafe(registry, () -> new EmiCraftingRecipe(List.of(
+						paper, paper, paper, paper,
+						EmiStack.of(Items.FILLED_MAP),
+						paper, paper, paper, paper
+				), 
+						EmiStack.of(Items.FILLED_MAP),
+						map.getId(), false), recipe);
+			} else if (recipe instanceof ShapedRecipe shaped && recipe.fits(3, 3)) {
 				addRecipeSafe(registry, () -> new EmiShapedRecipe(shaped), recipe);
 			} else if (recipe instanceof ShapelessRecipe shapeless && recipe.fits(3, 3)) {
 				addRecipeSafe(registry, () -> new EmiShapelessRecipe(shapeless), recipe);
@@ -273,6 +289,16 @@ public class VanillaPlugin implements EmiPlugin {
 				addRecipeSafe(registry, () -> new EmiFireworkStarFadeRecipe(star.getId()), recipe);
 			} else if (recipe instanceof FireworkRocketRecipe rocket) {
 				addRecipeSafe(registry, () -> new EmiFireworkRocketRecipe(rocket.getId()), recipe);
+			} else if (recipe instanceof BannerDuplicateRecipe banner) {
+				for (Item i : EmiBannerDuplicateRecipe.BANNERS) {
+					addRecipeSafe(registry, () -> new EmiBannerDuplicateRecipe(i, null), recipe);
+				}
+			} else if (recipe instanceof RepairItemRecipe tool) {
+				for (Item i : EmiRepairItemRecipe.TOOLS) {
+					addRecipeSafe(registry, () -> new EmiRepairItemRecipe(i, null), recipe);
+				}
+			} else if (recipe instanceof MapCloningRecipe map) {
+				addRecipeSafe(registry, () -> new EmiMapCloningRecipe(map.getId()), recipe);
 			}
 		}
 

--- a/src/main/java/dev/emi/emi/recipe/special/EmiBannerDuplicateRecipe.java
+++ b/src/main/java/dev/emi/emi/recipe/special/EmiBannerDuplicateRecipe.java
@@ -32,7 +32,7 @@ public class EmiBannerDuplicateRecipe extends EmiPatternCraftingRecipe {
     public EmiBannerDuplicateRecipe(Item banner, Identifier id) {
         super(List.of(
                 EmiStack.of(banner),
-                EmiStack.of(banner)),
+                EmiStack.of(banner).setRemainder(EmiStack.of(banner))),
                 EmiStack.of(banner), id);
         this.banner = banner;
     }
@@ -42,17 +42,17 @@ public class EmiBannerDuplicateRecipe extends EmiPatternCraftingRecipe {
         if (slot == 0) {
             return new SlotWidget(EmiStack.of(banner), x, y);
         } else if (slot == 1) {
-            return new GeneratedSlotWidget(this::getPattern, unique, x, y);
+            return new GeneratedSlotWidget(r -> getPattern(r, true), unique, x, y);
         }
         return new SlotWidget(EmiStack.EMPTY, x, y);
     }
 
     @Override
     public SlotWidget getOutputWidget(int x, int y) {
-        return new GeneratedSlotWidget(this::getPattern, unique, x, y);
+        return new GeneratedSlotWidget(r -> getPattern(r, false) , unique, x, y);
     }
 
-    public EmiStack getPattern(Random random) {
+    public EmiStack getPattern(Random random, boolean reminder) {
         ItemStack stack = new ItemStack(banner);
         int patterns = 1 + Math.max(random.nextInt(5), random.nextInt(3));
         BannerPattern.Patterns pattern = new BannerPattern.Patterns();
@@ -65,6 +65,10 @@ public class EmiBannerDuplicateRecipe extends EmiPatternCraftingRecipe {
 
         BlockItem.setBlockEntityNbt(stack, BlockEntityType.BANNER, tag);
         //stack.setNbt(tag);
-        return EmiStack.of(stack);
+        EmiStack emiStack = EmiStack.of(stack);
+        if (reminder) {
+            emiStack.setRemainder(EmiStack.of(stack));
+        }
+        return emiStack;
     }
 }

--- a/src/main/java/dev/emi/emi/recipe/special/EmiBannerDuplicateRecipe.java
+++ b/src/main/java/dev/emi/emi/recipe/special/EmiBannerDuplicateRecipe.java
@@ -1,0 +1,70 @@
+package dev.emi.emi.recipe.special;
+
+import java.util.List;
+import java.util.Random;
+
+import dev.emi.emi.EmiPort;
+import dev.emi.emi.api.recipe.EmiPatternCraftingRecipe;
+import dev.emi.emi.api.stack.EmiStack;
+import dev.emi.emi.api.widget.GeneratedSlotWidget;
+import dev.emi.emi.api.widget.SlotWidget;
+
+import net.minecraft.block.entity.BannerPattern;
+import net.minecraft.block.entity.BlockEntityType;
+import net.minecraft.item.BlockItem;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.util.Identifier;
+
+public class EmiBannerDuplicateRecipe extends EmiPatternCraftingRecipe {
+
+    public static final List<Item> BANNERS = List.of(
+            Items.WHITE_BANNER, Items.ORANGE_BANNER, Items.MAGENTA_BANNER, Items.LIGHT_BLUE_BANNER,
+            Items.YELLOW_BANNER, Items.LIME_BANNER, Items.PINK_BANNER, Items.GRAY_BANNER,
+            Items.LIGHT_GRAY_BANNER, Items.CYAN_BANNER, Items.PURPLE_BANNER, Items.BLUE_BANNER,
+            Items.BROWN_BANNER, Items.GREEN_BANNER, Items.RED_BANNER, Items.BLACK_BANNER
+    );
+
+    private final Item banner;
+
+    public EmiBannerDuplicateRecipe(Item banner, Identifier id) {
+        super(List.of(
+                EmiStack.of(banner),
+                EmiStack.of(banner)),
+                EmiStack.of(banner), id);
+        this.banner = banner;
+    }
+
+    @Override
+    public SlotWidget getInputWidget(int slot, int x, int y) {
+        if (slot == 0) {
+            return new SlotWidget(EmiStack.of(banner), x, y);
+        } else if (slot == 1) {
+            return new GeneratedSlotWidget(this::getPattern, unique, x, y);
+        }
+        return new SlotWidget(EmiStack.EMPTY, x, y);
+    }
+
+    @Override
+    public SlotWidget getOutputWidget(int x, int y) {
+        return new GeneratedSlotWidget(this::getPattern, unique, x, y);
+    }
+
+    public EmiStack getPattern(Random random) {
+        ItemStack stack = new ItemStack(banner);
+        int patterns = 1 + Math.max(random.nextInt(5), random.nextInt(3));
+        BannerPattern.Patterns pattern = new BannerPattern.Patterns();
+        for (int i = 0; i < patterns; i++) {
+            pattern = EmiPort.addRandomBanner(pattern, random);
+        }
+
+        NbtCompound tag = new NbtCompound();
+        tag.put("Patterns", pattern.toNbt());
+
+        BlockItem.setBlockEntityNbt(stack, BlockEntityType.BANNER, tag);
+        //stack.setNbt(tag);
+        return EmiStack.of(stack);
+    }
+}

--- a/src/main/java/dev/emi/emi/recipe/special/EmiBannerShieldRecipe.java
+++ b/src/main/java/dev/emi/emi/recipe/special/EmiBannerShieldRecipe.java
@@ -33,12 +33,7 @@ public class EmiBannerShieldRecipe extends EmiPatternCraftingRecipe {
 
 	@SuppressWarnings("unchecked")
 	public EmiBannerShieldRecipe(Identifier id) {
-		super((List<EmiIngredient>) (List<?>) Stream.concat(Stream.of(SHIELD), EMI_BANNERS.stream()).toList(), EmiStack.EMPTY, id);
-	}
-
-	@Override
-	public List<EmiStack> getOutputs() {
-		return EMI_BANNERS;
+		super((List<EmiIngredient>) (List<?>) Stream.concat(Stream.of(SHIELD), EMI_BANNERS.stream()).toList(), EmiStack.of(Items.SHIELD), id);
 	}
 
 	@Override

--- a/src/main/java/dev/emi/emi/recipe/special/EmiFireworkStarFadeRecipe.java
+++ b/src/main/java/dev/emi/emi/recipe/special/EmiFireworkStarFadeRecipe.java
@@ -89,6 +89,7 @@ public class EmiFireworkStarFadeRecipe extends EmiPatternCraftingRecipe {
 		for (DyeItem dyeItem : dyeItems) {
 			colors.add(dyeItem.getColor().getFireworkColor());
 		}
+		explosion.putIntArray("Colors", colors);
 
 		if (faded) {
 			List<DyeItem> dyeItemsFaded = getDyes(random, 8);

--- a/src/main/java/dev/emi/emi/recipe/special/EmiMapCloningRecipe.java
+++ b/src/main/java/dev/emi/emi/recipe/special/EmiMapCloningRecipe.java
@@ -1,0 +1,48 @@
+package dev.emi.emi.recipe.special;
+
+import dev.emi.emi.api.recipe.EmiPatternCraftingRecipe;
+import dev.emi.emi.api.stack.EmiStack;
+import dev.emi.emi.api.widget.GeneratedSlotWidget;
+import dev.emi.emi.api.widget.SlotWidget;
+
+import net.minecraft.item.Item;
+import net.minecraft.item.Items;
+import net.minecraft.util.Identifier;
+
+import java.util.List;
+import java.util.Random;
+
+public class EmiMapCloningRecipe extends EmiPatternCraftingRecipe {
+
+    public EmiMapCloningRecipe(Identifier id) {
+        super(List.of(
+                        EmiStack.of(Items.FILLED_MAP),
+                        EmiStack.of(Items.MAP)),
+                EmiStack.of(Items.FILLED_MAP), id);
+    }
+
+    @Override
+    public SlotWidget getInputWidget(int slot, int x, int y) {
+        if (slot == 0) {
+            return new SlotWidget(EmiStack.of(Items.FILLED_MAP), x, y);
+        } else {
+            final int s = slot - 1;
+            return new GeneratedSlotWidget(r -> {
+                int amount = r.nextInt(8) + 1;
+                if (s < amount) {
+                    return EmiStack.of(Items.MAP);
+                }
+                return EmiStack.EMPTY;
+            }, unique, x, y);
+        }
+    }
+
+    @Override
+    public SlotWidget getOutputWidget(int x, int y) {
+        return new GeneratedSlotWidget(r -> EmiStack.of(Items.FILLED_MAP, r.nextInt(8) + 2), unique, x, y);
+    }
+
+    public EmiStack getAmount(Random random, Item item) {
+        return EmiStack.of(item);
+    }
+}

--- a/src/main/java/dev/emi/emi/recipe/special/EmiRepairItemRecipe.java
+++ b/src/main/java/dev/emi/emi/recipe/special/EmiRepairItemRecipe.java
@@ -1,0 +1,73 @@
+package dev.emi.emi.recipe.special;
+
+import dev.emi.emi.api.recipe.EmiPatternCraftingRecipe;
+import dev.emi.emi.api.stack.EmiStack;
+import dev.emi.emi.api.widget.GeneratedSlotWidget;
+import dev.emi.emi.api.widget.SlotWidget;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
+import org.apache.commons.compress.utils.Lists;
+
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+public class EmiRepairItemRecipe extends EmiPatternCraftingRecipe {
+    public static final List<Item> TOOLS = Registry.ITEM.stream()
+            .filter(Item::isDamageable).collect(Collectors.toList());
+    private final Item tool;
+
+    public EmiRepairItemRecipe(Item tool, Identifier id) {
+        super(List.of(
+                EmiStack.of(tool),
+                EmiStack.of(tool)),
+                EmiStack.of(tool), id);
+        this.tool = tool;
+    }
+    @Override
+    public SlotWidget getInputWidget(int slot, int x, int y) {
+        return new GeneratedSlotWidget(r -> {
+            List<ItemStack> items = getItems(r);
+            if (slot < 2) {
+                return EmiStack.of(items.get(slot));
+            }
+            return EmiStack.EMPTY;
+
+        }, unique, x, y);
+    }
+
+    @Override
+    public SlotWidget getOutputWidget(int x, int y) {
+        return new GeneratedSlotWidget(r -> EmiStack.of(getMergeItems(r)), unique, x, y);
+    }
+
+    private List<ItemStack> getItems(Random random) {
+        List<ItemStack> items = Lists.newArrayList();
+        items.add(getTool(random));
+        items.add(getTool(random));
+        return items;
+    }
+
+    private ItemStack getMergeItems(Random random) {
+        List<ItemStack> items = getItems(random);
+        ItemStack item = tool.getDefaultStack();
+        int maxDamage = tool.getMaxDamage();
+        int damage = items.get(0).getDamage() - (21 * maxDamage)/20 + items.get(1).getDamage();
+        if (damage > 0) {
+            item.setDamage(damage);
+        }
+        return item;
+    }
+
+    private ItemStack getTool(Random r) {
+        ItemStack stack = tool.getDefaultStack();
+        if (stack.getMaxDamage() <= 0) {
+            return stack;
+        }
+        int d = r.nextInt(stack.getMaxDamage());
+        stack.setDamage(d);
+        return stack;
+    }
+}


### PR DESCRIPTION
This adds the following recipes:

- Banner Duplication
- Map Cloning
- Item Repair (Crafting Table version)

This fixes:

- Map extending having empty map as recipe result
- Re adds one line I miss deleted in https://github.com/emilyploszaj/emi/pull/52/commits/fab9d6d065ce2eb550cca8182f625762542635ee
- Banner Shields not being listed as a  recipe when clicking on shields