### PR TITLE
Handling For Horrible Horrible Contract-Breaking Non-PotionItem BrewingItemRecipes

### DIFF
--- a/fabric/src/main/java/dev/emi/emi/platform/fabric/EmiAgnosFabric.java
+++ b/fabric/src/main/java/dev/emi/emi/platform/fabric/EmiAgnosFabric.java
@@ -4,6 +4,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import dev.emi.emi.EmiPort;
 import dev.emi.emi.EmiRenderHelper;
@@ -34,12 +35,14 @@ import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.fluid.Fluid;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.PotionItem;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionUtil;
 import net.minecraft.potion.Potions;
 import net.minecraft.recipe.BrewingRecipeRegistry;
 import net.minecraft.recipe.Ingredient;
+import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 
@@ -128,7 +131,7 @@ public class EmiAgnosFabric extends EmiAgnos {
 					String gid = EmiUtil.subId(recipeIngredient.getMatchingStacks()[0].getItem());
 					String iid = EmiUtil.subId((Item) ((BrewingRecipeRegistryRecipeAccessor) recipe).getInput());
 					String oid = EmiUtil.subId((Item) ((BrewingRecipeRegistryRecipeAccessor) recipe).getOutput());
-					EmiPort.getPotionRegistry().streamEntries().forEach(entry -> {
+					Consumer<RegistryEntry<Potion>> potionRecipeGen = entry -> {
 						Potion potion = entry.value();
 						if (potion == Potions.EMPTY) {
 							return;
@@ -140,7 +143,12 @@ public class EmiAgnosFabric extends EmiAgnos {
 								EmiStack.of(PotionUtil.setPotion(new ItemStack((Item) ((BrewingRecipeRegistryRecipeAccessor) recipe).getInput()), potion)), EmiIngredient.of(recipeIngredient),
 								EmiStack.of(PotionUtil.setPotion(new ItemStack((Item) ((BrewingRecipeRegistryRecipeAccessor) recipe).getOutput()), potion)), id));
 						}
-					});
+					};
+					if ((((BrewingRecipeRegistryRecipeAccessor) recipe).getInput() instanceof PotionItem)) {
+						EmiPort.getPotionRegistry().streamEntries().forEach(potionRecipeGen);
+					} else {
+						potionRecipeGen.accept(EmiPort.getPotionRegistry().getEntry(Potions.AWKWARD));
+					}
 				}
 			} catch (Exception e) {
 				e.printStackTrace();

--- a/forge/src/main/java/dev/emi/emi/platform/forge/EmiAgnosForge.java
+++ b/forge/src/main/java/dev/emi/emi/platform/forge/EmiAgnosForge.java
@@ -4,8 +4,11 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 
+import net.minecraft.item.PotionItem;
+import net.minecraft.registry.entry.RegistryEntry;
 import org.objectweb.asm.Type;
 
 import com.google.common.collect.Lists;
@@ -155,7 +158,7 @@ public class EmiAgnosForge extends EmiAgnos {
 					String gid = EmiUtil.subId(recipe.ingredient.getMatchingStacks()[0].getItem());
 					String iid = EmiUtil.subId(recipe.f_43532_.get());
 					String oid = EmiUtil.subId(recipe.f_43534_.get());
-					EmiPort.getPotionRegistry().streamEntries().forEach(entry -> {
+					Consumer<RegistryEntry<Potion>> potionRecipeGen = entry -> {
 						Potion potion = entry.value();
 						if (potion == Potions.EMPTY) {
 							return;
@@ -167,7 +170,13 @@ public class EmiAgnosForge extends EmiAgnos {
 								EmiStack.of(PotionUtil.setPotion(new ItemStack(recipe.f_43532_.get()), potion)), EmiIngredient.of(recipe.ingredient),
 								EmiStack.of(PotionUtil.setPotion(new ItemStack(recipe.f_43534_.get()), potion)), id));
 						}
-					});
+					};
+					if ((recipe.f_43532_.get() instanceof PotionItem)) {
+						EmiPort.getPotionRegistry().streamEntries().forEach(potionRecipeGen);
+					} else {
+						potionRecipeGen.accept(EmiPort.getPotionRegistry().getEntry(Potions.AWKWARD));
+					}
+
 				}
 			} catch (Exception e) {
 				e.printStackTrace();


### PR DESCRIPTION
Using brewing for non-potions! very bad idea! breaks implicit contracts of the game! except it only takes a [couple](https://github.com/HestiMae/pollinators-paradise/blob/1.20/src/main/java/garden/hestia/pollinators_paradise/mixin/PotionSlotMixin.java) of [mixins](https://github.com/HestiMae/pollinators-paradise/blob/1.20/src/main/java/garden/hestia/pollinators_paradise/mixin/BrewingRecipeRegistryMixin.java) to allow Brewing`itemRecipes`, which are usually used for transforming _any_ potion from one PotionItem to another, to be used for a [regular item->item transformation recipe](https://github.com/HestiMae/pollinators-paradise/blob/1.20/src/main/java/garden/hestia/pollinators_paradise/PollinatorsParadise.java#L67).

In a regular item->item recipe, the potion NBT being clipped onto the item does nothing - meaning you get 14 pages of identical recipe displays - but! If we check for the input being PotionItem _while_ generating displays, we can pass it just one potion instead if it's a funky little contract breaker.

We were going to just mixin/api into EMI for this one, but the idea was thrown around that this might be the desired behaviour in general for most mods breaking this contract - so hey why not PR it!

Tested (on fabric at least) and doesn't break gunpowder!

-- Clawby