### PR TITLE
Allow simultaneous highlighting of defaulted and hidden stacks in index

### DIFF
--- a/xplat/src/main/java/dev/emi/emi/screen/EmiScreenManager.java
+++ b/xplat/src/main/java/dev/emi/emi/screen/EmiScreenManager.java
@@ -1589,16 +1589,12 @@ public class EmiScreenManager {
 						EmiIngredient stack = stacks.get(i++);
 						batcher.render(stack, context.raw(), cx + 1, cy + 1, delta);
 						if (getType() == SidebarType.INDEX) {
-							if (EmiConfig.editMode) {
-								if (EmiHidden.isHidden(stack)) {
-									RenderSystem.enableDepthTest();
-									context.fill(cx, cy, ENTRY_SIZE, ENTRY_SIZE, 0x33ff0000);
-								}
-							} else if (EmiConfig.highlightDefaulted) {
-								if (BoM.getRecipe(stack) != null) {
-									RenderSystem.enableDepthTest();
-									context.fill(cx, cy, ENTRY_SIZE, ENTRY_SIZE, 0x3300ff00);
-								}
+							if (EmiConfig.editMode && EmiHidden.isHidden(stack)) {
+								RenderSystem.enableDepthTest();
+								context.fill(cx, cy, ENTRY_SIZE, ENTRY_SIZE, 0x33ff0000);
+							} else if (EmiConfig.highlightDefaulted && BoM.getRecipe(stack) != null) {
+								RenderSystem.enableDepthTest();
+								context.fill(cx, cy, ENTRY_SIZE, ENTRY_SIZE, 0x3300ff00);
 							}
 						}
 					}


### PR DESCRIPTION
Fixes a bug where the `Highlight Defaulted` setting would be ignored when `Edit Mode` was enabled.

![image](https://github.com/emilyploszaj/emi/assets/4203804/4560a908-d448-44e9-b139-b1af25413975)
