### PR TITLE
Use loose generics as much as possible

### DIFF
--- a/xplat/src/main/java/dev/emi/emi/api/recipe/EmiInfoRecipe.java
+++ b/xplat/src/main/java/dev/emi/emi/api/recipe/EmiInfoRecipe.java
@@ -12,16 +12,17 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.text.OrderedText;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
+import org.jetbrains.annotations.Unmodifiable;
 
 public class EmiInfoRecipe implements EmiRecipe {
 	private static final int STACK_WIDTH = 6, MAX_STACKS = STACK_WIDTH * 3;
 	private static final int PADDING = 4;
 	private static final MinecraftClient CLIENT = MinecraftClient.getInstance();
-	private final List<EmiIngredient> stacks;
+	private final List<? extends EmiIngredient> stacks;
 	private final List<OrderedText> text;
 	private final Identifier id;
 
-	public EmiInfoRecipe(List<EmiIngredient> stacks, List<Text> text, @Nullable Identifier id) {
+	public EmiInfoRecipe(List<? extends EmiIngredient> stacks, List<? extends Text> text, @Nullable Identifier id) {
 		this.stacks = stacks;
 		this.text = text.stream().flatMap(t -> CLIENT.textRenderer.wrapLines(t, getDisplayWidth() - 4).stream()).toList();
 		this.id = id;
@@ -38,12 +39,12 @@ public class EmiInfoRecipe implements EmiRecipe {
 	}
 
 	@Override
-	public List<EmiIngredient> getInputs() {
+	public @Unmodifiable List<? extends EmiIngredient> getInputs() {
 		return stacks;
 	}
 
 	@Override
-	public List<EmiStack> getOutputs() {
+	public @Unmodifiable List<? extends EmiStack> getOutputs() {
 		return stacks.stream().flatMap(ing -> ing.getEmiStacks().stream()).toList();
 	}
 

--- a/xplat/src/main/java/dev/emi/emi/api/recipe/EmiIngredientRecipe.java
+++ b/xplat/src/main/java/dev/emi/emi/api/recipe/EmiIngredientRecipe.java
@@ -19,17 +19,17 @@ public abstract class EmiIngredientRecipe implements EmiRecipe {
 
 	protected abstract EmiIngredient getIngredient();
 
-	protected abstract List<EmiStack> getStacks();
+	protected abstract List<? extends EmiStack> getStacks();
 
 	protected abstract EmiRecipe getRecipeContext(EmiStack stack, int offset);
 
 	@Override
-	public List<EmiIngredient> getInputs() {
+	public List<? extends EmiIngredient> getInputs() {
 		return List.of(new ListEmiIngredient(getStacks(), 1));
 	}
 
 	@Override
-	public List<EmiStack> getOutputs() {
+	public List<? extends EmiStack> getOutputs() {
 		return List.of();
 	}
 
@@ -50,7 +50,7 @@ public abstract class EmiIngredientRecipe implements EmiRecipe {
 
 	@Override
 	public void addWidgets(WidgetHolder widgets) {
-		List<EmiStack> stacks = getStacks();
+		var stacks = getStacks();
 		widgets.addSlot(getIngredient(), 63, 0);
 		int ph = (widgets.getHeight() - 42) / 18;
 		int pageSize = (ph + 1) * 8;
@@ -69,11 +69,11 @@ public abstract class EmiIngredientRecipe implements EmiRecipe {
 	}
 
 	private class PageManager {
-		public final List<EmiStack> stacks;
+		public final List<? extends EmiStack> stacks;
 		public final int pageSize;
 		public int currentPage;
 
-		public PageManager(List<EmiStack> stacks, int pageSize) {
+		public PageManager(List<? extends EmiStack> stacks, int pageSize) {
 			this.stacks = stacks;
 			this.pageSize = pageSize;
 		}

--- a/xplat/src/main/java/dev/emi/emi/api/recipe/EmiRecipe.java
+++ b/xplat/src/main/java/dev/emi/emi/api/recipe/EmiRecipe.java
@@ -8,6 +8,7 @@ import dev.emi.emi.api.stack.EmiIngredient;
 import dev.emi.emi.api.stack.EmiStack;
 import dev.emi.emi.api.widget.WidgetHolder;
 import net.minecraft.util.Identifier;
+import org.jetbrains.annotations.Unmodifiable;
 
 public interface EmiRecipe {
 
@@ -21,19 +22,19 @@ public interface EmiRecipe {
 	 * @return The unique id of the recipe, or null. If null, the recipe cannot be serialized.
 	 */
 	@Nullable Identifier getId();
-	
+
 	/**
 	 * @return A list of ingredients required for the recipe.
 	 * 	Inputs will consider this recipe a use when exploring recipes.
 	 */
-	List<EmiIngredient> getInputs();
-	
+	@Unmodifiable List<? extends EmiIngredient> getInputs();
+
 	/**
 	 * @return A list of ingredients associated with the creation of the recipe.
 	 * 	Catalysts are considered the same as workstations in the recipe, not broken down as a requirement.
 	 * 	However, catalysts will consider this recipe a use when exploring recipes.
 	 */
-	default List<EmiIngredient> getCatalysts() {
+	default @Unmodifiable List<? extends EmiIngredient> getCatalysts() {
 		return List.of();
 	}
 
@@ -41,7 +42,7 @@ public interface EmiRecipe {
 	 * @return A list of stacks that are created after a craft.
 	 * 	Outputs will consider this recipe a source when exploring recipes.
 	 */
-	List<EmiStack> getOutputs();
+    @Unmodifiable List<? extends EmiStack> getOutputs();
 
 	/**
 	 * @return The width taken up by the recipe's widgets
@@ -55,7 +56,7 @@ public interface EmiRecipe {
 	/**
 	 * @return The maximum height taken up by the recipe's widgets.
 	 * 	Vertical screen space is capped, however, and EMI may opt to provide less vertical space.
-	 * 
+	 *
 	 * @see {@link WidgetHolder#getHeight()} when adding widgets for the EMI adjusted height.
 	 */
 	int getDisplayHeight();

--- a/xplat/src/main/java/dev/emi/emi/api/recipe/handler/StandardRecipeHandler.java
+++ b/xplat/src/main/java/dev/emi/emi/api/recipe/handler/StandardRecipeHandler.java
@@ -113,7 +113,7 @@ public interface StandardRecipeHandler<T extends ScreenHandler> extends EmiRecip
 	private static Map<EmiIngredient, Boolean> getAvailable(EmiRecipe recipe, EmiPlayerInventory inventory) {
 		Map<EmiIngredient, Boolean> availableForCrafting = new IdentityHashMap<>();
 		List<Boolean> list = inventory.getCraftAvailability(recipe);
-		List<EmiIngredient> inputs = recipe.getInputs();
+		var inputs = recipe.getInputs();
 		if (list.size() != inputs.size()) {
 			return Map.of();
 		}

--- a/xplat/src/main/java/dev/emi/emi/api/stack/EmiIngredient.java
+++ b/xplat/src/main/java/dev/emi/emi/api/stack/EmiIngredient.java
@@ -11,18 +11,19 @@ import net.minecraft.fluid.Fluid;
 import net.minecraft.item.Item;
 import net.minecraft.recipe.Ingredient;
 import net.minecraft.registry.tag.TagKey;
+import org.jetbrains.annotations.Unmodifiable;
 
 public interface EmiIngredient extends EmiRenderable {
-	public static final int RENDER_ICON = 1;
-	public static final int RENDER_AMOUNT = 2;
-	public static final int RENDER_INGREDIENT = 4;
-	public static final int RENDER_REMAINDER = 8;
+	int RENDER_ICON = 1;
+	int RENDER_AMOUNT = 2;
+	int RENDER_INGREDIENT = 4;
+	int RENDER_REMAINDER = 8;
 	
 	/**
 	 * @return The {@link EmiStack}s represented by this ingredient.
 	 * 	List is never empty. For an empty ingredient, us {@link EmiStack#EMPTY}
 	 */
-	List<EmiStack> getEmiStacks();
+	@Unmodifiable List<? extends EmiStack> getEmiStacks();
 
 	default boolean isEmpty() {
 		for (EmiStack stack : getEmiStacks()) {
@@ -50,11 +51,11 @@ public interface EmiIngredient extends EmiRenderable {
 
 	void render(DrawContext draw, int x, int y, float delta, int flags);
 
-	List<TooltipComponent> getTooltip();
+	@Unmodifiable List<? extends TooltipComponent> getTooltip();
 
-	public static boolean areEqual(EmiIngredient a, EmiIngredient b) {
-		List<EmiStack> as = a.getEmiStacks();
-		List<EmiStack> bs = b.getEmiStacks();
+	static boolean areEqual(EmiIngredient a, EmiIngredient b) {
+		var as = a.getEmiStacks();
+		var bs = b.getEmiStacks();
 		if (as.size() != bs.size()) {
 			return false;
 		}
@@ -66,30 +67,30 @@ public interface EmiIngredient extends EmiRenderable {
 		return true;
 	}
 
-	public static <T> EmiIngredient of(TagKey<T> key) {
+	static <T> EmiIngredient of(TagKey<T> key) {
 		return of(key, 1);
 	}
 
-	public static <T> EmiIngredient of(TagKey<T> key, long amount) {
+	static <T> EmiIngredient of(TagKey<T> key, long amount) {
 		return EmiIngredient.of(EmiTags.getRawValues(key), amount);
 	}
 
-	public static EmiIngredient of(Ingredient ingredient) {
+	static EmiIngredient of(Ingredient ingredient) {
 		return of(ingredient, 1);
 	}
 
-	public static EmiIngredient of(Ingredient ingredient, long amount) {
+	static EmiIngredient of(Ingredient ingredient, long amount) {
 		if (ingredient == null) {
 			return EmiStack.EMPTY;
 		}
 		return EmiTags.getIngredient(Item.class, Arrays.stream(ingredient.getMatchingStacks()).map(EmiStack::of).toList(), amount);
 	}
 
-	public static EmiIngredient of(List<? extends EmiIngredient> list) {
+	static EmiIngredient of(List<? extends EmiIngredient> list) {
 		return of(list, 1);
 	}
 
-	public static EmiIngredient of(List<? extends EmiIngredient> list, long amount) {
+	static EmiIngredient of(List<? extends EmiIngredient> list, long amount) {
 		if (list.size() == 0) {
 			return EmiStack.EMPTY;
 		} else if (list.size() == 1) {

--- a/xplat/src/main/java/dev/emi/emi/api/stack/ListEmiIngredient.java
+++ b/xplat/src/main/java/dev/emi/emi/api/stack/ListEmiIngredient.java
@@ -15,7 +15,7 @@ import net.minecraft.client.gui.tooltip.TooltipComponent;
 @ApiStatus.Internal
 public class ListEmiIngredient implements EmiIngredient {
 	private final List<? extends EmiIngredient> ingredients;
-	private final List<EmiStack> fullList;
+	private final List<? extends EmiStack> fullList;
 	private long amount;
 	private float chance = 1;
 
@@ -55,7 +55,7 @@ public class ListEmiIngredient implements EmiIngredient {
 	}
 
 	@Override
-	public List<EmiStack> getEmiStacks() {
+	public List<? extends EmiStack> getEmiStacks() {
 		return fullList;
 	}
 
@@ -86,7 +86,7 @@ public class ListEmiIngredient implements EmiIngredient {
 		int item = (int) (System.currentTimeMillis() / 1000 % ingredients.size());
 		EmiIngredient current = ingredients.get(item);
 		if ((flags & RENDER_ICON) != 0) {
-			current.render(draw, x, y, delta, -1 ^ RENDER_AMOUNT);
+			current.render(draw, x, y, delta, ~RENDER_AMOUNT);
 		}
 		if ((flags & RENDER_AMOUNT) != 0) {
 			current.copy().setAmount(amount).render(draw, x, y, delta, RENDER_AMOUNT);
@@ -97,7 +97,7 @@ public class ListEmiIngredient implements EmiIngredient {
 	}
 
 	@Override
-	public List<TooltipComponent> getTooltip() {
+	public List<? extends TooltipComponent> getTooltip() {
 		List<TooltipComponent> tooltip = Lists.newArrayList();
 		tooltip.add(TooltipComponent.of(EmiPort.ordered(EmiPort.translatable("tooltip.emi.accepts"))));
 		tooltip.add(new IngredientTooltipComponent(ingredients));

--- a/xplat/src/main/java/dev/emi/emi/bom/TreeCost.java
+++ b/xplat/src/main/java/dev/emi/emi/bom/TreeCost.java
@@ -180,22 +180,22 @@ public class TreeCost {
 			amount = node.amount;
 		}
 		long original = amount;
-		List<EmiStack> ingredientStacks = node.ingredient.getEmiStacks();
-		for (int i = 0; i < ingredientStacks.size(); i++) {
-			if (chance.chanced()) {
-				double desired = amount * chance.chance();
-				double given = getChancedRemainder(ingredientStacks.get(i), desired, catalyst, chance);
-				if (given > 0) {
-					double scaled = given / chance.chance();
-					amount -= (long) scaled;
-					if (amount > 0) {
-						chance = new ChanceState((float) ((amount - (scaled % 1)) * chance.chance() / amount), true);
-					}
-				}
-			} else {
-				amount -= getRemainder(ingredientStacks.get(i), amount, catalyst);
-			}
-		}
+		var ingredientStacks = node.ingredient.getEmiStacks();
+        for (EmiStack ingredientStack : ingredientStacks) {
+            if (chance.chanced()) {
+                double desired = amount * chance.chance();
+                double given = getChancedRemainder(ingredientStack, desired, catalyst, chance);
+                if (given > 0) {
+                    double scaled = given / chance.chance();
+                    amount -= (long) scaled;
+                    if (amount > 0) {
+                        chance = new ChanceState((float) ((amount - (scaled % 1)) * chance.chance() / amount), true);
+                    }
+                }
+            } else {
+                amount -= getRemainder(ingredientStack, amount, catalyst);
+            }
+        }
 		if (amount == 0) {
 			if (trackProgress) {
 				complete(node);

--- a/xplat/src/main/java/dev/emi/emi/recipe/EmiShapedRecipe.java
+++ b/xplat/src/main/java/dev/emi/emi/recipe/EmiShapedRecipe.java
@@ -22,7 +22,7 @@ public class EmiShapedRecipe extends EmiCraftingRecipe {
 		setRemainders(input, recipe);
 	}
 
-	public static void setRemainders(List<EmiIngredient> input, CraftingRecipe recipe) {
+	public static void setRemainders(List<? extends EmiIngredient> input, CraftingRecipe recipe) {
 		try {
 			CraftingInventory inv = EmiUtil.getCraftingInventory();
 			for (int i = 0; i < input.size(); i++) {
@@ -37,7 +37,7 @@ public class EmiShapedRecipe extends EmiCraftingRecipe {
 						inv.setStack(j, input.get(j).getEmiStacks().get(0).getItemStack().copy());
 					}
 				}
-				List<EmiStack> stacks = input.get(i).getEmiStacks();
+				var stacks = input.get(i).getEmiStacks();
 				for (EmiStack stack : stacks) {
 					inv.setStack(i, stack.getItemStack().copy());
 					ItemStack remainder = recipe.getRemainder(inv).get(i);

--- a/xplat/src/main/java/dev/emi/emi/recipe/EmiSyntheticIngredientRecipe.java
+++ b/xplat/src/main/java/dev/emi/emi/recipe/EmiSyntheticIngredientRecipe.java
@@ -24,7 +24,7 @@ public class EmiSyntheticIngredientRecipe extends EmiIngredientRecipe {
 	}
 
 	@Override
-	protected List<EmiStack> getStacks() {
+	protected List<? extends EmiStack> getStacks() {
 		return ingredient.getEmiStacks();
 	}
 

--- a/xplat/src/main/java/dev/emi/emi/recipe/EmiTagRecipe.java
+++ b/xplat/src/main/java/dev/emi/emi/recipe/EmiTagRecipe.java
@@ -15,7 +15,7 @@ import net.minecraft.registry.tag.TagKey;
 import net.minecraft.util.Identifier;
 
 public class EmiTagRecipe extends EmiIngredientRecipe {
-	private final List<EmiStack> stacks;
+	private final List<? extends EmiStack> stacks;
 	private final EmiIngredient ingredient;
 	public final TagKey<?> key;
 
@@ -31,7 +31,7 @@ public class EmiTagRecipe extends EmiIngredientRecipe {
 	}
 
 	@Override
-	protected List<EmiStack> getStacks() {
+	protected List<? extends EmiStack> getStacks() {
 		return stacks;
 	}
 

--- a/xplat/src/main/java/dev/emi/emi/registry/EmiTags.java
+++ b/xplat/src/main/java/dev/emi/emi/registry/EmiTags.java
@@ -1,11 +1,9 @@
 package dev.emi.emi.registry;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -72,7 +70,7 @@ public class EmiTags {
 	}
 
 	@SuppressWarnings({"unchecked", "rawtypes"})
-	public static <T> EmiIngredient getIngredient(Class<T> clazz, List<EmiStack> stacks, long amount) {
+	public static <T> EmiIngredient getIngredient(Class<T> clazz, List<? extends EmiStack> stacks, long amount) {
 		Registry<T> registry;
 		if (clazz == Item.class) {
 			registry = (Registry<T>) EmiPort.getItemRegistry();
@@ -122,7 +120,7 @@ public class EmiTags {
 			CACHED_TAGS.put((Set) original, (List) keys);
 		}
 
-		if (keys == null || keys.isEmpty()) {
+		if (keys.isEmpty()) {
 			return new ListEmiIngredient(stacks.stream().toList(), amount);
 		} else if (map.isEmpty()) {
 			if (keys.size() == 1) {
@@ -131,9 +129,8 @@ public class EmiTags {
 				return new ListEmiIngredient(keys.stream().map(k -> tagIngredient(k, 1)).toList(), amount);
 			}
 		} else {
-			return new ListEmiIngredient(List.of(map.values().stream().map(i -> i.copy().setAmount(1)).toList(),
-					keys.stream().map(k -> tagIngredient(k, 1)).toList())
-				.stream().flatMap(a -> a.stream()).toList(), amount);
+			return new ListEmiIngredient(Stream.of(map.values().stream().map(i -> i.copy().setAmount(1)).toList(),
+					keys.stream().map(k -> tagIngredient(k, 1)).toList()).flatMap(Collection::stream).toList(), amount);
 		}
 	}
 

--- a/xplat/src/main/java/dev/emi/emi/runtime/EmiFavorite.java
+++ b/xplat/src/main/java/dev/emi/emi/runtime/EmiFavorite.java
@@ -61,12 +61,12 @@ public class EmiFavorite implements EmiIngredient, Batchable {
 		return this;
 	}
 
-	public EmiRecipe getRecipe() {
+	public @Nullable EmiRecipe getRecipe() {
 		return recipe;
 	}
 
 	@Override
-	public List<EmiStack> getEmiStacks() {
+	public List<? extends EmiStack> getEmiStacks() {
 		return stack.getEmiStacks();
 	}
 
@@ -93,8 +93,8 @@ public class EmiFavorite implements EmiIngredient, Batchable {
 	}
 
 	public boolean strictEquals(EmiIngredient other) {
-		List<EmiStack> as = this.getEmiStacks();
-		List<EmiStack> bs = other.getEmiStacks();
+		var as = this.getEmiStacks();
+		var bs = other.getEmiStacks();
 		if (as.size() != bs.size()) {
 			return false;
 		}

--- a/xplat/src/main/java/dev/emi/emi/screen/BoMScreen.java
+++ b/xplat/src/main/java/dev/emi/emi/screen/BoMScreen.java
@@ -403,7 +403,7 @@ public class BoMScreen extends Screen {
 	private boolean getAutoResolutions(Hover hover, BiConsumer<EmiIngredient, EmiRecipe> consumer) {
 		EmiPlayerInventory inv = EmiScreenManager.lastPlayerInventory;
 		if (inv != null) {
-			List<EmiStack> stacks = hover.stack.getEmiStacks();
+			var stacks = hover.stack.getEmiStacks();
 			if (stacks.size() > 1) {
 				for (EmiStack stack : stacks) {
 					if (inv.inventory.containsKey(stack)) {

--- a/xplat/src/main/java/dev/emi/emi/search/EmiSearch.java
+++ b/xplat/src/main/java/dev/emi/emi/search/EmiSearch.java
@@ -249,7 +249,7 @@ public class EmiSearch {
 							return;
 						}
 					}
-					List<EmiStack> ess = stack.getEmiStacks();
+					var ess = stack.getEmiStacks();
 					// TODO properly support ingredients?
 					if (ess.size() == 1) {
 						EmiStack es = ess.get(0);


### PR DESCRIPTION
Before, you need to cast generics in some cases:
```java
List<EmiStack> all;
@Override
public List<EmiIngredient> getInputs() {
    return (List<EmiIngredient>) (List<? extends EmiIngredient>) all;
}
@Override
public List<EmiStack> getOutputs() {
    return all;
}
```
Now you can just return it directly:
```java
List<EmiStack> all;
@Override
public List<? extends EmiIngredient> getInputs() {
    return all;
}
@Override
public List<? extends EmiStack> getOutputs() {
    return all;
}
```