### PR TITLE
NeoForge 1.20.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,11 @@ jobs:
 #          RELEASE: true
 #        run: ./gradlew :forge:build
 
+      - name: Build NeoForge
+        env:
+          RELEASE: true
+        run: ./gradlew :neoforge:build
+
       - name: Publish
         env:
           MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ dependencies {
 	compileOnly fg.deobf("dev.emi:emi-forge:${emi_version}:api")
 	runtimeOnly fg.deobf("dev.emi:emi-forge:${emi_version}") 
 
+	// NeoForge
+	compileOnly "dev.emi:emi-neoforge:${emi_version}:api"
+	runtimeOnly dev.emi:emi-neoforge:${emi_version}" 
+
 	// Architectury
 	modCompileOnly "dev.emi:emi-xplat-intermediary:${emi_version}:api"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.jvmargs=-Xmx2048M
 
 minecraft_version=1.20.4
-enabled_platforms=fabric
+enabled_platforms=fabric,neoforge
 
 archives_base_name=emi
 mod_version=1.0.28
@@ -15,5 +15,7 @@ fabric_loader_version=0.15.2
 fabric_api_version=0.91.3+1.20.4
 
 forge_version=1.20.4-49.0.9
+
+neoforge_version=20.4.56-beta
 
 jei_version=jei-1.20.2-fabric:16.0.0.28

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -1,0 +1,197 @@
+buildscript {
+	repositories {
+		mavenCentral()
+		gradlePluginPortal()
+	}
+	dependencies {
+		classpath 'com.modrinth.minotaur:Minotaur:2.4.3'
+		classpath 'gradle.plugin.com.matthewprenger:CurseGradle:1.4.0'
+	}
+}
+
+plugins {
+	id "dev.architectury.loom"
+	id "com.github.johnrengelman.shadow" version "7.1.2"
+}
+if (System.getenv("MODRINTH_TOKEN")) {
+	apply plugin: "com.modrinth.minotaur"
+}
+if (System.getenv("CURSEFORGE_TOKEN")) {
+	apply plugin: "com.matthewprenger.cursegradle"
+}
+evaluationDependsOn ':xplat'
+
+architectury {
+	platformSetupLoomIde()
+	neoForge()
+}
+
+loom {
+	accessWidenerPath = project(":xplat").loom.accessWidenerPath
+
+	mods {
+		main {
+			sourceSet project(':xplat').sourceSets.main
+		}
+	}
+}
+
+repositories {
+	maven {
+		url "https://maven.neoforged.net/releases/"
+		content {
+			includeGroupAndSubgroups "net.neoforged"
+			includeGroupAndSubgroups "cpw.mods"
+		}
+	}
+}
+
+configurations {
+	common
+	shadowCommon
+	compileClasspath.extendsFrom common
+	runtimeClasspath.extendsFrom common
+	developmentNeoForge.extendsFrom common
+}
+
+dependencies {
+	minecraft "com.mojang:minecraft:${rootProject.minecraft_version}"
+	mappings "net.fabricmc:yarn:${rootProject.yarn_mappings}:v2"
+
+	neoForge "net.neoforged:neoforge:${rootProject.neoforge_version}"
+
+	common(project(path: ":xplat", configuration: "namedElements")) { transitive = false }
+	shadowCommon(project(path: ":xplat", configuration: "transformProductionNeoForge")) { transitive = false }
+}
+
+processResources {
+	inputs.property "version", project.version
+
+	filesMatching("META-INF/mods.toml") {
+		expand "version": project.version
+	}
+}
+
+shadowJar {
+	exclude "fabric.mod.json"
+	exclude "architectury.common.json"
+
+	configurations = [project.configurations.shadowCommon]
+	archiveClassifier = "dev-shadow"
+}
+
+remapJar {
+	input.set shadowJar.archiveFile
+	dependsOn shadowJar
+}
+
+sourcesJar {
+	def commonSources = project(":xplat").sourcesJar
+	dependsOn commonSources
+	from commonSources.archiveFile.map { zipTree(it) }
+}
+
+task filteredSourcesJar(type: Jar) {
+	archiveClassifier = 'filtered-sources'
+	dependsOn remapSourcesJar
+	from zipTree(remapSourcesJar.archivePath)
+	exclude 'dev/emi/emi/jemi/**'
+}
+
+task apiJar(type: Jar) {
+	archiveClassifier = 'api'
+	dependsOn remapJar
+	from zipTree(remapJar.archivePath)
+	include 'emi.mixins.json'
+	include 'emi-neoforge.mixins.json'
+	include 'emi.accesswidener'
+	include 'dev/emi/emi/api/**'
+	exclude 'dev/emi/emi/api/EmiRecipeHandler**'
+	exclude 'dev/emi/emi/api/stack/FluidEmiStack**'
+	exclude 'dev/emi/emi/api/stack/ItemEmiStack**'
+	exclude 'dev/emi/emi/api/stack/EmptyEmiStack**'
+	exclude 'dev/emi/emi/api/stack/TagEmiIngredient**'
+	exclude 'dev/emi/emi/api/stack/ListEmiIngredient**'
+}
+
+build.dependsOn filteredSourcesJar
+build.dependsOn apiJar
+
+components.java {
+	withVariantsFromConfiguration(project.configurations.shadowRuntimeElements) {
+		skip()
+	}
+}
+
+publishing {
+	publications {
+		maven(MavenPublication) {
+			artifactId = "${rootProject.name}-${project.name}"
+			version = project.ext.mavenVersion
+			artifact(remapJar) {
+				builtBy remapJar
+				classifier ''
+			}
+			artifact(filteredSourcesJar) {
+				builtBy filteredSourcesJar
+				classifier 'sources'
+			}
+			artifact(apiJar) {
+				builtBy apiJar
+				classifier 'api'
+			}
+		}
+	}
+	setupRepositories(repositories)
+}
+
+void setupRepositories(RepositoryHandler repositories) {
+	if (project.hasProperty("mavenUrl")) {
+		repositories.maven {
+			url project.mavenUrl
+			credentials {
+				username project.mavenUsername
+				password project.mavenPassword
+			}
+		}
+	}
+}
+
+if (System.getenv("MODRINTH_TOKEN")) {
+	modrinth {
+		token = System.getenv("MODRINTH_TOKEN")
+		projectId = 'emi'
+		versionNumber = project.version
+		versionName = project.version
+		versionType = 'release'
+		uploadFile = remapJar
+		gameVersions = [rootProject.minecraft_version]
+		loaders = ['neoforge']
+		detectLoaders = false
+		changelog = file('../CHANGELOG.md').text
+	}
+}
+
+if (System.getenv("CURSEFORGE_TOKEN")) {
+	curseforge {
+		apiKey = System.getenv("CURSEFORGE_TOKEN")
+		project {
+			id = '580555'
+			releaseType = 'release'
+			changelogType = 'markdown'
+			changelog = file('../CHANGELOG.md')
+
+			addGameVersion rootProject.minecraft_version
+			addGameVersion 'NeoForge'
+
+			mainArtifact(remapJar) {
+				displayName = 'emi-' + project.version
+			}
+		}
+		options {
+			javaIntegration = false
+			forgeGradleIntegration = false
+			javaVersionAutoDetect = false
+		}
+	}
+}

--- a/neoforge/gradle.properties
+++ b/neoforge/gradle.properties
@@ -1,0 +1,1 @@
+loom.platform=neoforge

--- a/neoforge/src/main/java/dev/emi/emi/api/neoforge/NeoForgeEmiStack.java
+++ b/neoforge/src/main/java/dev/emi/emi/api/neoforge/NeoForgeEmiStack.java
@@ -1,0 +1,11 @@
+package dev.emi.emi.api.neoforge;
+
+import dev.emi.emi.api.stack.EmiStack;
+import net.neoforged.neoforge.fluids.FluidStack;
+
+public final class NeoForgeEmiStack {
+	
+	public static EmiStack of(FluidStack stack) {
+		return EmiStack.of(stack.getFluid(), stack.getTag(), stack.getAmount());
+	}
+}

--- a/neoforge/src/main/java/dev/emi/emi/platform/neoforge/EmiAgnosNeoForge.java
+++ b/neoforge/src/main/java/dev/emi/emi/platform/neoforge/EmiAgnosNeoForge.java
@@ -1,0 +1,285 @@
+package dev.emi.emi.platform.neoforge;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import net.minecraft.item.PotionItem;
+import net.minecraft.registry.entry.RegistryEntry;
+import net.neoforged.neoforge.client.ClientHooks;
+import net.neoforged.neoforge.common.CommonHooks;
+import org.objectweb.asm.Type;
+
+import com.google.common.collect.Lists;
+
+import dev.emi.emi.EmiPort;
+import dev.emi.emi.EmiRenderHelper;
+import dev.emi.emi.EmiUtil;
+import dev.emi.emi.api.EmiEntrypoint;
+import dev.emi.emi.api.EmiPlugin;
+import dev.emi.emi.api.EmiRegistry;
+import dev.emi.emi.api.stack.EmiIngredient;
+import dev.emi.emi.api.stack.EmiStack;
+import dev.emi.emi.api.stack.FluidEmiStack;
+import dev.emi.emi.platform.EmiAgnos;
+import dev.emi.emi.recipe.EmiBrewingRecipe;
+import dev.emi.emi.registry.EmiPluginContainer;
+import dev.emi.emi.runtime.EmiLog;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.tooltip.TooltipComponent;
+import net.minecraft.client.render.item.ItemRenderer;
+import net.minecraft.client.render.model.BakedModel;
+import net.minecraft.client.render.model.BasicBakedModel;
+import net.minecraft.client.texture.Sprite;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.fluid.Fluid;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.potion.Potion;
+import net.minecraft.potion.PotionUtil;
+import net.minecraft.potion.Potions;
+import net.minecraft.recipe.BrewingRecipeRegistry;
+import net.minecraft.recipe.Ingredient;
+import net.minecraft.screen.PlayerScreenHandler;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+import net.neoforged.neoforge.client.extensions.common.IClientFluidTypeExtensions;
+import net.neoforged.neoforge.common.brewing.BrewingRecipe;
+import net.neoforged.neoforge.common.brewing.IBrewingRecipe;
+import net.neoforged.neoforge.fluids.FluidStack;
+import net.neoforged.fml.ModContainer;
+import net.neoforged.fml.ModList;
+import net.neoforged.fml.loading.FMLLoader;
+import net.neoforged.fml.loading.FMLPaths;
+import net.neoforged.neoforgespi.language.ModFileScanData;
+
+public class EmiAgnosNeoForge extends EmiAgnos {
+	static {
+		EmiAgnos.delegate = new EmiAgnosNeoForge();
+	}
+
+	@Override
+	protected boolean isForgeAgnos() {
+		return true;
+	}
+
+	@Override
+	protected String getModNameAgnos(String namespace) {
+		if (namespace.equals("c")) {
+			return "Common";
+		}
+		Optional<? extends ModContainer> container = ModList.get().getModContainerById(namespace);
+		if (container.isPresent()) {
+			return container.get().getModInfo().getDisplayName();
+		}
+		return namespace;
+	}
+
+	@Override
+	protected Path getConfigDirectoryAgnos() {
+		return FMLPaths.CONFIGDIR.get();
+	}
+
+	@Override
+	protected boolean isDevelopmentEnvironmentAgnos() {
+		return !FMLLoader.isProduction();
+	}
+
+	@Override
+	protected boolean isModLoadedAgnos(String id) {
+		return ModList.get().isLoaded(id);
+	}
+
+	@Override
+	protected List<String> getAllModNamesAgnos() {
+		return ModList.get().getMods().stream().map(m -> m.getDisplayName()).toList();
+	}
+
+	@Override
+	protected List<EmiPluginContainer> getPluginsAgnos() {
+		List<EmiPluginContainer> containers = Lists.newArrayList();
+		Type entrypointType = Type.getType(EmiEntrypoint.class);
+		for (ModFileScanData data : ModList.get().getAllScanData()) {
+			for (ModFileScanData.AnnotationData annot : data.getAnnotations()) {
+				try {
+					if (entrypointType.equals(annot.annotationType())) {
+						Class<?> clazz = Class.forName(annot.memberName());
+						if (EmiPlugin.class.isAssignableFrom(clazz)) {
+							Class<? extends EmiPlugin> pluginClass = clazz.asSubclass(EmiPlugin.class);
+							EmiPlugin plugin = pluginClass.getConstructor().newInstance();
+							String id = data.getIModInfoData().get(0).getMods().get(0).getModId();
+							containers.add(new EmiPluginContainer(plugin, id));
+						} else {
+							EmiLog.error("EmiEntrypoint " + annot.memberName() + " does not implement EmiPlugin");
+						}
+					}
+				} catch (Throwable t) {
+					EmiLog.error("Exception constructing entrypoint:");
+					t.printStackTrace();
+				}
+			}
+		}
+		return containers;
+	}
+
+	@Override
+	protected void addBrewingRecipesAgnos(EmiRegistry registry) {
+		for (Ingredient ingredient : BrewingRecipeRegistry.POTION_TYPES) {
+			for (ItemStack stack : ingredient.getMatchingStacks()) {
+				String pid = EmiUtil.subId(stack.getItem());
+				for (BrewingRecipeRegistry.Recipe<Potion> recipe : BrewingRecipeRegistry.POTION_RECIPES) {
+					try {
+						if (recipe.ingredient.getMatchingStacks().length > 0) {
+							Identifier id = new Identifier("emi", "/brewing/" + pid
+								+ "/" + EmiUtil.subId(recipe.ingredient.getMatchingStacks()[0].getItem())
+								+ "/" + EmiUtil.subId(EmiPort.getPotionRegistry().getId(recipe.input))
+								+ "/" + EmiUtil.subId(EmiPort.getPotionRegistry().getId(recipe.output)));
+							registry.addRecipe(new EmiBrewingRecipe(
+								EmiStack.of(PotionUtil.setPotion(stack.copy(), recipe.input)), EmiIngredient.of(recipe.ingredient),
+								EmiStack.of(PotionUtil.setPotion(stack.copy(), recipe.output)), id));
+						}
+					} catch (Exception e) {
+						e.printStackTrace();
+					}
+				}
+			}
+		}
+
+		for (BrewingRecipeRegistry.Recipe<Item> recipe : BrewingRecipeRegistry.ITEM_RECIPES) {
+			try {
+				if (recipe.ingredient.getMatchingStacks().length > 0) {
+					String gid = EmiUtil.subId(recipe.ingredient.getMatchingStacks()[0].getItem());
+					String iid = EmiUtil.subId(recipe.input);
+					String oid = EmiUtil.subId(recipe.output);
+					Consumer<RegistryEntry<Potion>> potionRecipeGen = entry -> {
+						Potion potion = entry.value();
+						if (potion == Potions.EMPTY) {
+							return;
+						}
+						if (BrewingRecipeRegistry.isBrewable(potion)) {
+							Identifier id = new Identifier("emi", "brewing/item/"
+								+ EmiUtil.subId(entry.getKey().get().getValue()) + "/" + gid + "/" + iid + "/" + oid);
+							registry.addRecipe(new EmiBrewingRecipe(
+								EmiStack.of(PotionUtil.setPotion(new ItemStack(recipe.input), potion)), EmiIngredient.of(recipe.ingredient),
+								EmiStack.of(PotionUtil.setPotion(new ItemStack(recipe.output), potion)), id));
+						}
+					};
+					if ((recipe.input instanceof PotionItem)) {
+						EmiPort.getPotionRegistry().streamEntries().forEach(potionRecipeGen);
+					} else {
+						potionRecipeGen.accept(EmiPort.getPotionRegistry().getEntry(Potions.AWKWARD));
+					}
+
+				}
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+		}
+		for (IBrewingRecipe ibr : net.neoforged.neoforge.common.brewing.BrewingRecipeRegistry.getRecipes()) {
+			try {
+				if (ibr instanceof BrewingRecipe recipe) {
+					for (ItemStack is : recipe.getInput().getMatchingStacks()) {
+						EmiStack input = EmiStack.of(is);
+						EmiIngredient ingredient = EmiIngredient.of(recipe.getIngredient());
+						EmiStack output = EmiStack.of(recipe.getOutput(is, recipe.getIngredient().getMatchingStacks()[0]));
+						Identifier id = new Identifier("emi", "brewing/neoforge/"
+							+ EmiUtil.subId(input.getId()) + "/"
+							+ EmiUtil.subId(ingredient.getEmiStacks().get(0).getId()) + "/"
+							+ EmiUtil.subId(output.getId()));
+						registry.addRecipe(new EmiBrewingRecipe(input, ingredient, output, id));
+					}
+				}
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+		}
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	protected List<String> getAllModAuthorsAgnos() {
+		return ModList.get().getMods().stream().flatMap(m -> {
+			Optional<Object> opt = m.getConfig().getConfigElement("authors");
+			if (opt.isPresent()) {
+				Object obj = opt.get();
+				if (obj instanceof String authors) {
+					return Lists.newArrayList(authors.split("\\,")).stream().map(s -> s.trim());
+				} else if (obj instanceof List<?> list) {
+					if (list.size() > 0 && list.get(0) instanceof String) {
+						List<String> authors = (List<String>) list;
+						return authors.stream();
+					}
+				}
+			}
+			return Stream.empty();
+		}).distinct().toList();
+	}
+
+	@Override
+	protected List<TooltipComponent> getItemTooltipAgnos(ItemStack stack) {
+		MinecraftClient client = MinecraftClient.getInstance();
+		return ClientHooks.gatherTooltipComponents(stack, Screen.getTooltipFromItem(client, stack), stack.getTooltipData(), 0, Integer.MAX_VALUE, Integer.MAX_VALUE, client.textRenderer);
+	}
+
+	@Override
+	protected Text getFluidNameAgnos(Fluid fluid, NbtCompound nbt) {
+		return new FluidStack(fluid, 1000, nbt).getDisplayName();
+	}
+
+	@Override
+	protected List<Text> getFluidTooltipAgnos(Fluid fluid, NbtCompound nbt) {
+		return List.of(getFluidName(fluid, nbt));
+	}
+
+	@Override
+	protected boolean isFloatyFluidAgnos(FluidEmiStack stack) {
+		FluidStack fs = new FluidStack(stack.getKeyOfType(Fluid.class), 1000, stack.getNbt());
+		return fs.getFluid().getFluidType().isLighterThanAir();
+	}
+
+	@Override
+	protected void renderFluidAgnos(FluidEmiStack stack, MatrixStack matrices, int x, int y, float delta, int xOff, int yOff, int width, int height) {
+		FluidStack fs = new FluidStack(stack.getKeyOfType(Fluid.class), 1000, stack.getNbt());
+		IClientFluidTypeExtensions ext = IClientFluidTypeExtensions.of(fs.getFluid());
+		Identifier texture = ext.getStillTexture(fs);
+		int color = ext.getTintColor(fs);
+		MinecraftClient client = MinecraftClient.getInstance();
+		Sprite sprite = client.getSpriteAtlas(PlayerScreenHandler.BLOCK_ATLAS_TEXTURE).apply(texture);
+		EmiRenderHelper.drawTintedSprite(matrices, sprite, color, x, y, xOff, yOff, width, height);
+	}
+
+	@Override
+	protected EmiStack createFluidStackAgnos(Object object) {
+		if (object instanceof FluidStack f) {
+			return EmiStack.of(f.getFluid(), f.getTag(), f.getAmount());
+		}
+		return EmiStack.EMPTY;
+	}
+
+	@Override
+	protected boolean canBatchAgnos(ItemStack stack) {
+		MinecraftClient client = MinecraftClient.getInstance();
+		ItemRenderer ir = client.getItemRenderer();
+		BakedModel model = ir.getModel(stack, client.world, null, 0);
+		return model != null && model.getClass() == BasicBakedModel.class;
+	}
+
+	@Override
+	protected Map<Item, Integer> getFuelMapAgnos() {
+		Object2IntMap<Item> fuelMap = new Object2IntOpenHashMap<>();
+		for (Item item : EmiPort.getItemRegistry()) {
+			int time = CommonHooks.getBurnTime(item.getDefaultStack(), null);
+			if (time > 0) {
+				fuelMap.put(item, time);
+			}
+		}
+		return fuelMap;
+	}
+}

--- a/neoforge/src/main/java/dev/emi/emi/platform/neoforge/EmiClientNeoForge.java
+++ b/neoforge/src/main/java/dev/emi/emi/platform/neoforge/EmiClientNeoForge.java
@@ -1,0 +1,80 @@
+package dev.emi.emi.platform.neoforge;
+
+import java.util.Arrays;
+
+import dev.emi.emi.EmiPort;
+import dev.emi.emi.data.EmiData;
+import dev.emi.emi.network.EmiNetwork;
+import dev.emi.emi.platform.EmiClient;
+import dev.emi.emi.registry.EmiTags;
+import dev.emi.emi.runtime.EmiDrawContext;
+import dev.emi.emi.runtime.EmiReloadManager;
+import dev.emi.emi.screen.ConfigScreen;
+import dev.emi.emi.screen.EmiScreen;
+import dev.emi.emi.screen.EmiScreenManager;
+import dev.emi.emi.screen.StackBatcher;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.neoforge.client.ConfigScreenHandler;
+import net.neoforged.neoforge.client.NeoForgeRenderTypes;
+import net.neoforged.neoforge.client.event.ContainerScreenEvent;
+import net.neoforged.neoforge.client.event.ModelEvent;
+import net.neoforged.neoforge.client.event.RecipesUpdatedEvent;
+import net.neoforged.neoforge.client.event.RegisterClientReloadListenersEvent;
+import net.neoforged.neoforge.common.NeoForge;
+import net.neoforged.neoforge.event.TagsUpdatedEvent;
+import net.neoforged.fml.ModLoadingContext;
+import net.neoforged.fml.common.Mod;
+import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
+import net.neoforged.neoforge.network.PacketDistributor;
+
+@Mod.EventBusSubscriber(modid = "emi", bus = Mod.EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
+public class EmiClientNeoForge {
+	
+	@SubscribeEvent
+	public static void clientInit(FMLClientSetupEvent event) {
+		StackBatcher.EXTRA_RENDER_LAYERS.addAll(Arrays.stream(NeoForgeRenderTypes.values()).map(f -> f.get()).toList());
+		EmiClient.init();
+		EmiNetwork.initClient(packet -> EmiPacketHandler.CHANNEL.send(PacketDistributor.SERVER.noArg(), packet));
+		NeoForge.EVENT_BUS.addListener(EmiClientNeoForge::recipesReloaded);
+		NeoForge.EVENT_BUS.addListener(EmiClientNeoForge::tagsReloaded);
+		NeoForge.EVENT_BUS.addListener(EmiClientNeoForge::renderScreenForeground);
+		ModLoadingContext.get().registerExtensionPoint(ConfigScreenHandler.ConfigScreenFactory.class,
+			() -> new ConfigScreenHandler.ConfigScreenFactory((client, last) -> new ConfigScreen(last)));
+	}
+
+	@SubscribeEvent
+	public static void registerAdditionalModels(ModelEvent.RegisterAdditional event) {
+		MinecraftClient client = MinecraftClient.getInstance();
+		EmiTags.registerTagModels(client.getResourceManager(), event::register);
+	}
+
+	@SubscribeEvent
+	public static void registerResourceReloaders(RegisterClientReloadListenersEvent event) {
+		EmiData.init(reloader -> event.registerReloadListener(reloader));
+	}
+
+	public static void recipesReloaded(RecipesUpdatedEvent event) {
+		EmiReloadManager.reloadRecipes();
+	}
+
+	public static void tagsReloaded(TagsUpdatedEvent event) {
+		EmiReloadManager.reloadTags();
+	}
+
+	public static void renderScreenForeground(ContainerScreenEvent.Render.Foreground event) {
+		EmiDrawContext context = EmiDrawContext.wrap(event.getGuiGraphics());
+		HandledScreen<?> screen = event.getContainerScreen();
+		if (screen instanceof EmiScreen emi) {
+			MinecraftClient client = MinecraftClient.getInstance();
+			context.push();
+			context.matrices().translate(-emi.emi$getLeft(), -emi.emi$getTop(), 0.0);
+			EmiPort.setPositionTexShader();
+			EmiScreenManager.render(context, event.getMouseX(), event.getMouseY(), client.getTickDelta());
+			EmiScreenManager.drawForeground(context, event.getMouseX(), event.getMouseY(), client.getTickDelta());
+			context.pop();
+		}
+	}
+}

--- a/neoforge/src/main/java/dev/emi/emi/platform/neoforge/EmiNeoForge.java
+++ b/neoforge/src/main/java/dev/emi/emi/platform/neoforge/EmiNeoForge.java
@@ -1,0 +1,36 @@
+package dev.emi.emi.platform.neoforge;
+
+import dev.emi.emi.network.EmiNetwork;
+import dev.emi.emi.network.PingS2CPacket;
+import dev.emi.emi.platform.EmiMain;
+import dev.emi.emi.registry.EmiCommands;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.neoforged.neoforge.common.NeoForge;
+import net.neoforged.neoforge.event.RegisterCommandsEvent;
+import net.neoforged.neoforge.event.entity.player.PlayerEvent;
+import net.neoforged.fml.common.Mod;
+import net.neoforged.neoforge.network.PacketDistributor;
+
+@Mod("emi")
+public class EmiNeoForge {
+
+	public EmiNeoForge() {
+		EmiMain.init();
+		EmiPacketHandler.init();
+		EmiNetwork.initServer((player, packet) -> {
+			EmiPacketHandler.CHANNEL.send(PacketDistributor.PLAYER.with(() -> player), packet);
+		});
+		NeoForge.EVENT_BUS.addListener(this::registerCommands);
+		NeoForge.EVENT_BUS.addListener(this::playerConnect);
+	}
+
+	public void registerCommands(RegisterCommandsEvent event) {
+		EmiCommands.registerCommands(event.getDispatcher());
+	}
+
+	public void playerConnect(PlayerEvent.PlayerLoggedInEvent event) {
+		if (event.getEntity() instanceof ServerPlayerEntity spe) {
+			EmiNetwork.sendToClient(spe, new PingS2CPacket());
+		}
+	}
+}

--- a/neoforge/src/main/java/dev/emi/emi/platform/neoforge/EmiPacketHandler.java
+++ b/neoforge/src/main/java/dev/emi/emi/platform/neoforge/EmiPacketHandler.java
@@ -1,0 +1,62 @@
+package dev.emi.emi.platform.neoforge;
+
+import java.util.function.BiConsumer;
+
+import dev.emi.emi.network.CommandS2CPacket;
+import dev.emi.emi.network.CreateItemC2SPacket;
+import dev.emi.emi.network.EmiChessPacket;
+import dev.emi.emi.network.FillRecipeC2SPacket;
+import dev.emi.emi.network.PingS2CPacket;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.Identifier;
+import net.neoforged.neoforge.network.NetworkRegistry;
+import net.neoforged.neoforge.network.PlayNetworkDirection;
+import net.neoforged.neoforge.network.simple.MessageFunctions;
+import net.neoforged.neoforge.network.simple.SimpleChannel;
+
+public class EmiPacketHandler {
+	public static final SimpleChannel CHANNEL = NetworkRegistry.ChannelBuilder.named(new Identifier("emi:emi"))
+		.networkProtocolVersion(() -> "1")
+		.clientAcceptedVersions((version) -> true)
+		.serverAcceptedVersions((version) -> true)
+		.simpleChannel();
+
+	public static void init() {
+		int i = 0;
+		CHANNEL.messageBuilder(FillRecipeC2SPacket.class, i++, PlayNetworkDirection.PLAY_TO_SERVER)
+			.encoder(FillRecipeC2SPacket::write).decoder(FillRecipeC2SPacket::new)
+			.consumerMainThread(serverHandler(FillRecipeC2SPacket::apply)).add();
+		CHANNEL.messageBuilder(CreateItemC2SPacket.class, i++, PlayNetworkDirection.PLAY_TO_SERVER)
+			.encoder(CreateItemC2SPacket::write).decoder(CreateItemC2SPacket::new)
+			.consumerMainThread(serverHandler(CreateItemC2SPacket::apply)).add();
+		CHANNEL.messageBuilder(EmiChessPacket.C2S.class, i++, PlayNetworkDirection.PLAY_TO_SERVER)
+			.encoder(EmiChessPacket.C2S::write).decoder(EmiChessPacket.C2S::new)
+			.consumerMainThread(serverHandler(EmiChessPacket.C2S::apply)).add();
+
+		CHANNEL.messageBuilder(PingS2CPacket.class, i++, PlayNetworkDirection.PLAY_TO_CLIENT)
+			.encoder(PingS2CPacket::write).decoder(PingS2CPacket::new)
+			.consumerMainThread(clientHandler(PingS2CPacket::apply)).add();
+		CHANNEL.messageBuilder(CommandS2CPacket.class, i++, PlayNetworkDirection.PLAY_TO_CLIENT)
+			.encoder(CommandS2CPacket::write).decoder(CommandS2CPacket::new)
+			.consumerMainThread(clientHandler(CommandS2CPacket::apply)).add();
+		CHANNEL.messageBuilder(EmiChessPacket.S2C.class, i++, PlayNetworkDirection.PLAY_TO_CLIENT)
+			.encoder(EmiChessPacket.S2C::write).decoder(EmiChessPacket.S2C::new)
+			.consumerMainThread(clientHandler(EmiChessPacket.S2C::apply)).add();
+	}
+
+	private static <T> MessageFunctions.MessageConsumer<T> serverHandler(BiConsumer<T, PlayerEntity> handler) {
+		return (t, context) -> {
+			handler.accept(t, context.getSender());
+			context.setPacketHandled(true);
+		};
+	}
+
+	private static <T> MessageFunctions.MessageConsumer<T> clientHandler(BiConsumer<T, PlayerEntity> handler) {
+		return (t, context) -> {
+			MinecraftClient client = MinecraftClient.getInstance();
+			handler.accept(t, client.player);
+			context.setPacketHandled(true);
+		};
+	}
+}

--- a/neoforge/src/main/resources/META-INF/accesstransformer.cfg
+++ b/neoforge/src/main/resources/META-INF/accesstransformer.cfg
@@ -1,0 +1,10 @@
+public net.minecraft.world.item.alchemy.PotionBrewing$Mix
+
+public net.minecraft.world.item.alchemy.PotionBrewing POTION_MIXES
+public net.minecraft.world.item.alchemy.PotionBrewing CONTAINER_MIXES
+public net.minecraft.world.item.alchemy.PotionBrewing ALLOWED_CONTAINERS
+
+public net.minecraft.client.gui.screens.Screen addWidget(Lnet/minecraft/client/gui/components/events/GuiEventListener;)Lnet/minecraft/client/gui/components/events/GuiEventListener;
+
+public net.minecraft.client.gui.components.AbstractWidget x
+public net.minecraft.client.gui.components.AbstractWidget y

--- a/neoforge/src/main/resources/META-INF/mods.toml
+++ b/neoforge/src/main/resources/META-INF/mods.toml
@@ -1,0 +1,20 @@
+modLoader = "javafml"
+loaderVersion = "[1,)"
+#issueTrackerURL = ""
+license = "MIT"
+
+[[mixins]]
+config="emi.mixins.json"
+
+[[mixins]]
+config="emi-neoforge.mixins.json"
+
+[[mods]]
+modId = "emi"
+version = "${version}"
+displayName = "EMI"
+authors = "Emi"
+description = '''
+A featureful and accessible item and recipe viewer
+'''
+logoFile = "icon.png"

--- a/neoforge/src/main/resources/emi-neoforge.mixins.json
+++ b/neoforge/src/main/resources/emi-neoforge.mixins.json
@@ -1,0 +1,13 @@
+{
+  "required": true,
+  "minVersion": "0.8",
+  "package": "dev.emi.emi.mixin.neoforge",
+  "compatibilityLevel": "JAVA_17",
+  "client": [
+  ],
+  "mixins": [
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/neoforge/src/main/resources/pack.mcmeta
+++ b/neoforge/src/main/resources/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+  "pack": {
+    "description": "EMI",
+    "pack_format": 8
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,5 +11,6 @@ include("xplat")
 include("xplat:mojmap")
 include("fabric")
 //include("forge")
+include("neoforge")
 
 rootProject.name = "emi"

--- a/xplat/src/main/java/dev/emi/emi/platform/EmiAgnos.java
+++ b/xplat/src/main/java/dev/emi/emi/platform/EmiAgnos.java
@@ -28,6 +28,10 @@ public abstract class EmiAgnos {
 			Class.forName("dev.emi.emi.platform.forge.EmiAgnosForge");
 		} catch (Throwable t) {
 		}
+		try {
+			Class.forName("dev.emi.emi.platform.neoforge.EmiAgnosNeoForge");
+		} catch (Throwable t) {
+		}
 	}
 
 	public static boolean isForge() {


### PR DESCRIPTION
Adds NeoForge 1.20.4 support.

Notes:
- ArchLoom doesn't seem to support accesswidener conversion for NeoForge for some reason. They are no longer in SRG for NF 1.20.2+. Rather, they are in MojMap now. I converted the accesswidener by hand to an AT in MojMap and placed it in the corresponding spot. Tested in AE2 dev, that this works correctly.
- Everything else still closely aligns with Forge