### PR TITLE
Add Minecraft Recipe IDs where appropriate

### DIFF
--- a/xplat/src/main/java/dev/emi/emi/VanillaPlugin.java
+++ b/xplat/src/main/java/dev/emi/emi/VanillaPlugin.java
@@ -344,7 +344,7 @@ public class VanillaPlugin implements EmiPlugin {
 					Identifier sid = synthetic("crafting/shulker_box_dying", EmiUtil.subId(dyeItem));
 					addRecipeSafe(registry, () -> new EmiCraftingRecipe(
 						List.of(EmiStack.of(Items.SHULKER_BOX), EmiStack.of(dyeItem)),
-						EmiStack.of(ShulkerBoxBlock.getItemStack(dye)), sid), recipe);
+						EmiStack.of(ShulkerBoxBlock.getItemStack(dye)), sid, id), recipe);
 				}
 			} else if (recipe instanceof ShieldDecorationRecipe shield) {
 				addRecipeSafe(registry, () -> new EmiBannerShieldRecipe(id), recipe);
@@ -363,6 +363,7 @@ public class VanillaPlugin implements EmiPlugin {
 						),
 						EmiStack.of(PotionUtil.setPotion(new ItemStack(Items.TIPPED_ARROW, 8), entry.value())),
 						synthetic("crafting/tipped_arrow", EmiUtil.subId(EmiPort.getPotionRegistry().getId(entry.value()))),
+						id,
 						false), recipe);
 				});
 			} else if (recipe instanceof FireworkStarRecipe star) {

--- a/xplat/src/main/java/dev/emi/emi/api/recipe/EmiCraftingRecipe.java
+++ b/xplat/src/main/java/dev/emi/emi/api/recipe/EmiCraftingRecipe.java
@@ -8,9 +8,11 @@ import dev.emi.emi.api.stack.EmiStack;
 import dev.emi.emi.api.widget.WidgetHolder;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.Identifier;
+import org.jetbrains.annotations.Nullable;
 
 public class EmiCraftingRecipe implements EmiRecipe {
 	protected final Identifier id;
+	protected final Identifier minecraftRecipeId;
 	protected final List<EmiIngredient> input;
 	protected final EmiStack output;
 	public final boolean shapeless;
@@ -19,10 +21,19 @@ public class EmiCraftingRecipe implements EmiRecipe {
 		this(input, output, id, true);
 	}
 
+	public EmiCraftingRecipe(List<EmiIngredient> input, EmiStack output, Identifier id, @Nullable Identifier minecraftRecipeId) {
+		this(input, output, id, minecraftRecipeId,true);
+	}
+
 	public EmiCraftingRecipe(List<EmiIngredient> input, EmiStack output, Identifier id, boolean shapeless) {
+		this(input, output, id, null, shapeless);
+	}
+
+	public EmiCraftingRecipe(List<EmiIngredient> input, EmiStack output, Identifier id, @Nullable Identifier minecraftRecipeId, boolean shapeless) {
 		this.input = input;
 		this.output = output;
 		this.id = id;
+		this.minecraftRecipeId = minecraftRecipeId;
 		this.shapeless = shapeless;
 	}
 

--- a/xplat/src/main/java/dev/emi/emi/api/recipe/EmiPatternCraftingRecipe.java
+++ b/xplat/src/main/java/dev/emi/emi/api/recipe/EmiPatternCraftingRecipe.java
@@ -9,6 +9,7 @@ import dev.emi.emi.api.stack.EmiStack;
 import dev.emi.emi.api.widget.SlotWidget;
 import dev.emi.emi.api.widget.WidgetHolder;
 import net.minecraft.util.Identifier;
+import org.jetbrains.annotations.Nullable;
 
 public abstract class EmiPatternCraftingRecipe extends EmiCraftingRecipe {
 	protected final int unique = EmiUtil.RANDOM.nextInt();
@@ -16,9 +17,17 @@ public abstract class EmiPatternCraftingRecipe extends EmiCraftingRecipe {
 	public EmiPatternCraftingRecipe(List<EmiIngredient> input, EmiStack output, Identifier id) {
 		super(input, output, id);
 	}
-	
+
+	public EmiPatternCraftingRecipe(List<EmiIngredient> input, EmiStack output, Identifier id, @Nullable Identifier minecraftRecipeId) {
+		super(input, output, id, minecraftRecipeId);
+	}
+
 	public EmiPatternCraftingRecipe(List<EmiIngredient> input, EmiStack output, Identifier id, boolean shapeless) {
 		super(input, output, id, shapeless);
+	}
+
+	public EmiPatternCraftingRecipe(List<EmiIngredient> input, EmiStack output, Identifier id, @Nullable Identifier minecraftRecipeId, boolean shapeless) {
+		super(input, output, id, minecraftRecipeId, shapeless);
 	}
 
 	public abstract SlotWidget getInputWidget(int slot, int x, int y);

--- a/xplat/src/main/java/dev/emi/emi/api/recipe/EmiRecipe.java
+++ b/xplat/src/main/java/dev/emi/emi/api/recipe/EmiRecipe.java
@@ -2,6 +2,8 @@ package dev.emi.emi.api.recipe;
 
 import java.util.List;
 
+import net.minecraft.recipe.Recipe;
+import net.minecraft.recipe.RecipeEntry;
 import org.jetbrains.annotations.Nullable;
 
 import dev.emi.emi.api.stack.EmiIngredient;
@@ -21,6 +23,16 @@ public interface EmiRecipe {
 	 * @return The unique id of the recipe, or null. If null, the recipe cannot be serialized.
 	 */
 	@Nullable Identifier getId();
+
+	/**
+	 * @return Returns the identifier of the Minecraft recipe represented by this EMI recipe.
+	 *         Returns null for EMI recipes that don't have a  corresponding Minecraft recipe.
+	 *         The id of this recipe does not necessarily match {@link #getId()}.
+	 *         There can be multiple EMI recipes for the same Minecraft recipe.
+	 */
+	default @Nullable Identifier getMinecraftRecipeId() {
+		return null;
+	}
 	
 	/**
 	 * @return A list of ingredients required for the recipe.

--- a/xplat/src/main/java/dev/emi/emi/jemi/JemiPlugin.java
+++ b/xplat/src/main/java/dev/emi/emi/jemi/JemiPlugin.java
@@ -323,8 +323,9 @@ public class JemiPlugin implements IModPlugin, EmiPlugin {
 					}
 					if (inputs.stream().anyMatch(i -> !i.isEmpty()) && outputs.stream().anyMatch(o -> !o.isEmpty())) {
 						EmiRecipe replacement;
+						var id = category.getRegistryName(recipe);
 						if (outputs.size() > 1) {
-							replacement = new EmiPatternCraftingRecipe(inputs, EmiStack.EMPTY, category.getRegistryName(recipe), builder.shapeless) {
+							replacement = new EmiPatternCraftingRecipe(inputs, EmiStack.EMPTY, id, id, builder.shapeless) {
 
 								@Override
 								public List<EmiStack> getOutputs() {
@@ -347,7 +348,7 @@ public class JemiPlugin implements IModPlugin, EmiPlugin {
 								
 							};
 						} else {
-							replacement = new EmiCraftingRecipe(inputs, outputs.get(0), category.getRegistryName(recipe), builder.shapeless);
+							replacement = new EmiCraftingRecipe(inputs, outputs.get(0), id, id, builder.shapeless);
 						}
 						if (replacement.getId() != null) {
 							replaced.add(replacement.getId());

--- a/xplat/src/main/java/dev/emi/emi/recipe/EmiCookingRecipe.java
+++ b/xplat/src/main/java/dev/emi/emi/recipe/EmiCookingRecipe.java
@@ -15,6 +15,7 @@ import net.minecraft.fluid.Fluids;
 import net.minecraft.item.Items;
 import net.minecraft.recipe.AbstractCookingRecipe;
 import net.minecraft.util.Identifier;
+import org.jetbrains.annotations.Nullable;
 
 public class EmiCookingRecipe implements EmiRecipe {
 	private final Identifier id;
@@ -45,6 +46,11 @@ public class EmiCookingRecipe implements EmiRecipe {
 
 	@Override
 	public Identifier getId() {
+		return id;
+	}
+
+	@Override
+	public @Nullable Identifier getMinecraftRecipeId() {
 		return id;
 	}
 

--- a/xplat/src/main/java/dev/emi/emi/recipe/EmiShapedRecipe.java
+++ b/xplat/src/main/java/dev/emi/emi/recipe/EmiShapedRecipe.java
@@ -18,7 +18,7 @@ import net.minecraft.recipe.ShapedRecipe;
 public class EmiShapedRecipe extends EmiCraftingRecipe {
 
 	public EmiShapedRecipe(ShapedRecipe recipe) {
-		super(padIngredients(recipe), EmiStack.of(EmiPort.getOutput(recipe)), EmiPort.getId(recipe), false);
+		super(padIngredients(recipe), EmiStack.of(EmiPort.getOutput(recipe)), EmiPort.getId(recipe), EmiPort.getId(recipe), false);
 		setRemainders(input, recipe);
 	}
 

--- a/xplat/src/main/java/dev/emi/emi/recipe/EmiShapelessRecipe.java
+++ b/xplat/src/main/java/dev/emi/emi/recipe/EmiShapelessRecipe.java
@@ -10,7 +10,7 @@ public class EmiShapelessRecipe extends EmiCraftingRecipe {
 	
 	public EmiShapelessRecipe(ShapelessRecipe recipe) {
 		super(recipe.getIngredients().stream().map(i -> EmiIngredient.of(i)).toList(),
-			EmiStack.of(EmiPort.getOutput(recipe)), EmiPort.getId(recipe));
+			EmiStack.of(EmiPort.getOutput(recipe)), EmiPort.getId(recipe), EmiPort.getId(recipe));
 		EmiShapedRecipe.setRemainders(input, recipe);
 	}
 

--- a/xplat/src/main/java/dev/emi/emi/recipe/EmiSmithingRecipe.java
+++ b/xplat/src/main/java/dev/emi/emi/recipe/EmiSmithingRecipe.java
@@ -10,6 +10,7 @@ import dev.emi.emi.api.stack.EmiIngredient;
 import dev.emi.emi.api.stack.EmiStack;
 import dev.emi.emi.api.widget.WidgetHolder;
 import net.minecraft.util.Identifier;
+import org.jetbrains.annotations.Nullable;
 
 public class EmiSmithingRecipe implements EmiRecipe {
 	protected final Identifier id;
@@ -34,6 +35,11 @@ public class EmiSmithingRecipe implements EmiRecipe {
 	@Override
 	public Identifier getId() {
 		return id;
+	}
+
+	@Override
+	public @Nullable Identifier getMinecraftRecipeId() {
+		return id; // Our EmiRecipe id matches the Vanilla id
 	}
 
 	@Override

--- a/xplat/src/main/java/dev/emi/emi/recipe/EmiStonecuttingRecipe.java
+++ b/xplat/src/main/java/dev/emi/emi/recipe/EmiStonecuttingRecipe.java
@@ -12,6 +12,7 @@ import dev.emi.emi.api.stack.EmiStack;
 import dev.emi.emi.api.widget.WidgetHolder;
 import net.minecraft.recipe.StonecuttingRecipe;
 import net.minecraft.util.Identifier;
+import org.jetbrains.annotations.Nullable;
 
 public class EmiStonecuttingRecipe implements EmiRecipe {
 	private final Identifier id;
@@ -22,6 +23,11 @@ public class EmiStonecuttingRecipe implements EmiRecipe {
 		this.id = EmiPort.getId(recipe);
 		input = EmiIngredient.of(recipe.getIngredients().get(0));
 		output = EmiStack.of(EmiPort.getOutput(recipe));
+	}
+
+	@Override
+	public @Nullable Identifier getMinecraftRecipeId() {
+		return this.id;
 	}
 
 	@Override

--- a/xplat/src/main/java/dev/emi/emi/recipe/special/EmiFireworkRocketRecipe.java
+++ b/xplat/src/main/java/dev/emi/emi/recipe/special/EmiFireworkRocketRecipe.java
@@ -27,7 +27,7 @@ public class EmiFireworkRocketRecipe extends EmiPatternCraftingRecipe {
 				EmiStack.of(Items.PAPER),
 						EmiStack.of(Items.FIREWORK_STAR),
 						EmiStack.of(Items.GUNPOWDER)),
-				EmiStack.of(Items.FIREWORK_ROCKET), id);
+				EmiStack.of(Items.FIREWORK_ROCKET), id, id);
 	}
 
 	@Override

--- a/xplat/src/main/java/dev/emi/emi/recipe/special/EmiFireworkStarFadeRecipe.java
+++ b/xplat/src/main/java/dev/emi/emi/recipe/special/EmiFireworkStarFadeRecipe.java
@@ -25,7 +25,7 @@ public class EmiFireworkStarFadeRecipe extends EmiPatternCraftingRecipe {
 	public EmiFireworkStarFadeRecipe(Identifier id) {
 		super(List.of(
 			EmiIngredient.of(DYES.stream().map(i -> (EmiIngredient) EmiStack.of(i)).collect(Collectors.toList())),
-			EmiStack.of(Items.FIREWORK_STAR)), EmiStack.of(Items.FIREWORK_STAR), id);
+			EmiStack.of(Items.FIREWORK_STAR)), EmiStack.of(Items.FIREWORK_STAR), id, id);
 	}
 
 	@Override

--- a/xplat/src/main/java/dev/emi/emi/recipe/special/EmiFireworkStarRecipe.java
+++ b/xplat/src/main/java/dev/emi/emi/recipe/special/EmiFireworkStarRecipe.java
@@ -34,7 +34,7 @@ public class EmiFireworkStarRecipe extends EmiPatternCraftingRecipe {
 						EmiIngredient.of(SHAPES.stream().map(i -> (EmiIngredient) EmiStack.of(i)).collect(Collectors.toList())),
 						EmiIngredient.of(EFFECTS.stream().map(i -> (EmiIngredient) EmiStack.of(i)).collect(Collectors.toList())),
 						EmiStack.of(Items.GUNPOWDER)),
-				EmiStack.of(Items.FIREWORK_STAR), id);
+				EmiStack.of(Items.FIREWORK_STAR), id, id);
 	}
 
 	@Override

--- a/xplat/src/main/java/dev/emi/emi/recipe/special/EmiSuspiciousStewRecipe.java
+++ b/xplat/src/main/java/dev/emi/emi/recipe/special/EmiSuspiciousStewRecipe.java
@@ -28,7 +28,7 @@ public class EmiSuspiciousStewRecipe extends EmiPatternCraftingRecipe {
 				EmiStack.of(Items.RED_MUSHROOM),
 				EmiStack.of(Items.BROWN_MUSHROOM),
 				EmiIngredient.of(FLOWERS.stream().map(i -> (EmiIngredient) EmiStack.of(i)).collect(Collectors.toList()))),
-			EmiStack.of(Items.SUSPICIOUS_STEW), id);
+			EmiStack.of(Items.SUSPICIOUS_STEW), id, id);
 	}
 
 	@Override


### PR DESCRIPTION
To aid mods that need to correlate EMI recipes with Minecraft recipes (i.e. for saving references to them in NBT data or similar), this adds a defaulted method to access the Minecraft Recipe ID via EmiRecipe.
For many of the EMI recipes, this is just the normal recipe id (but not for all...).