### PR TITLE
Fix Focus Behavior after 1.20.4 Changes

### DIFF
--- a/xplat/src/main/java/dev/emi/emi/EmiPort.java
+++ b/xplat/src/main/java/dev/emi/emi/EmiPort.java
@@ -7,6 +7,8 @@ import java.util.Random;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
+import net.minecraft.client.gui.Element;
+import net.minecraft.client.gui.screen.Screen;
 import org.joml.Matrix4f;
 
 import com.mojang.blaze3d.systems.RenderSystem;
@@ -171,6 +173,14 @@ public final class EmiPort {
 	}
 
 	public static void focus(TextFieldWidget widget, boolean focused) {
+		// Also ensure a current focus-element in the screen is cleared if it changes
+		MinecraftClient client = MinecraftClient.getInstance();
+		if (client != null && client.currentScreen != null) {
+			var currentFocus = client.currentScreen.getFocused();
+			if (!focused && currentFocus == widget || focused && currentFocus != widget) {
+				client.currentScreen.focusOn(null);
+			}
+		}
 		widget.setFocused(focused);
 	}
 

--- a/xplat/src/main/java/dev/emi/emi/screen/widget/EmiSearchWidget.java
+++ b/xplat/src/main/java/dev/emi/emi/screen/widget/EmiSearchWidget.java
@@ -153,16 +153,16 @@ public class EmiSearchWidget extends TextFieldWidget {
 	public boolean isFocused() {
 		return isFocused;
 	}
-	
+
 	@Override
 	public boolean mouseClicked(double mouseX, double mouseY, int button) {
 		if (!isMouseOver(mouseX, mouseY) || !EmiConfig.enabled) {
-			setFocused(false);
+			EmiPort.focus(this, false);
 			return false;
 		} else {
 			boolean b = super.mouseClicked(mouseX, mouseY, button == 1 ? 0 : button);
 			if (isMouseOver(mouseX, mouseY)) {
-				setFocused(true);
+				EmiPort.focus(this, true);
 			}
 			if (this.isFocused()) {
 				if (button == 0) {
@@ -174,7 +174,7 @@ public class EmiSearchWidget extends TextFieldWidget {
 					}
 				} else if (button == 1) {
 					this.setText("");
-					this.setFocused(true);
+					EmiPort.focus(this, true);
 				}
 			}
 			return b;
@@ -190,8 +190,7 @@ public class EmiSearchWidget extends TextFieldWidget {
 			}
 			if ((EmiConfig.focusSearch.matchesKey(keyCode, scanCode)
 					|| keyCode == GLFW.GLFW_KEY_ENTER || keyCode == GLFW.GLFW_KEY_ESCAPE)) {
-				this.setFocused(false);
-				this.setFocused(false);
+				EmiPort.focus(this, false);
 				return true;
 			}
 		}


### PR DESCRIPTION
Th problem I observe in AE2 in 1.20.4. is: When the AE2 search widget has focus, and I click on EMIs search widget, the AE2 search box will remain focused.

This is due to Vanilla now maintaining the current focus widget in Screen (well, `AbstractParentElement`, really). This needs to be cleared when we move Focus to the EmiSearchWidget.

I tested this fix in the AE2 dev-environment (with moving focus between the two search-fields via clicks, and unfocusing by clicking elsewhere in the screen).

I also tested the creative inventory, where the creative search field maintain its visual focus state when EmiSearchWidget is focused, while inputs are correctly routed to EMI.