### PR TITLE
Mod name tooltips: match kebab case mod IDs, fall back to friendly namespaces

### DIFF
--- a/fabric/src/main/java/dev/emi/emi/platform/fabric/EmiAgnosFabric.java
+++ b/fabric/src/main/java/dev/emi/emi/platform/fabric/EmiAgnosFabric.java
@@ -45,6 +45,7 @@ import net.minecraft.recipe.Ingredient;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
+import org.apache.commons.lang3.text.WordUtils;
 
 public class EmiAgnosFabric extends EmiAgnos {
 	static {
@@ -69,7 +70,7 @@ public class EmiAgnosFabric extends EmiAgnos {
 		if (container.isPresent()) {
 			return container.get().getMetadata().getName();
 		}
-		return namespace;
+		return WordUtils.capitalizeFully(namespace.replace('_', ' '));
 	}
 
 	@Override

--- a/fabric/src/main/java/dev/emi/emi/platform/fabric/EmiAgnosFabric.java
+++ b/fabric/src/main/java/dev/emi/emi/platform/fabric/EmiAgnosFabric.java
@@ -57,6 +57,7 @@ public class EmiAgnosFabric extends EmiAgnos {
 		return false;
 	}
 
+	@SuppressWarnings("deprecation")
 	@Override
 	protected String getModNameAgnos(String namespace) {
 		if (namespace.equals("c")) {

--- a/fabric/src/main/java/dev/emi/emi/platform/fabric/EmiAgnosFabric.java
+++ b/fabric/src/main/java/dev/emi/emi/platform/fabric/EmiAgnosFabric.java
@@ -65,6 +65,10 @@ public class EmiAgnosFabric extends EmiAgnos {
 		if (container.isPresent()) {
 			return container.get().getMetadata().getName();
 		}
+		container = FabricLoader.getInstance().getModContainer(namespace.replace('_', '-'));
+		if (container.isPresent()) {
+			return container.get().getMetadata().getName();
+		}
 		return namespace;
 	}
 

--- a/forge/src/main/java/dev/emi/emi/platform/forge/EmiAgnosForge.java
+++ b/forge/src/main/java/dev/emi/emi/platform/forge/EmiAgnosForge.java
@@ -79,6 +79,10 @@ public class EmiAgnosForge extends EmiAgnos {
 		if (container.isPresent()) {
 			return container.get().getModInfo().getDisplayName();
 		}
+		container = ModList.get().getModContainerById(namespace.replace('_', '-'));
+		if (container.isPresent()) {
+			return container.get().getModInfo().getDisplayName();
+		}
 		return namespace;
 	}
 

--- a/forge/src/main/java/dev/emi/emi/platform/forge/EmiAgnosForge.java
+++ b/forge/src/main/java/dev/emi/emi/platform/forge/EmiAgnosForge.java
@@ -83,7 +83,7 @@ public class EmiAgnosForge extends EmiAgnos {
 		if (container.isPresent()) {
 			return container.get().getModInfo().getDisplayName();
 		}
-		return namespace;
+		return WordUtils.capitalizeFully(namespace.replace('_', ' '));
 	}
 
 	@Override

--- a/forge/src/main/java/dev/emi/emi/platform/forge/EmiAgnosForge.java
+++ b/forge/src/main/java/dev/emi/emi/platform/forge/EmiAgnosForge.java
@@ -70,6 +70,7 @@ public class EmiAgnosForge extends EmiAgnos {
 		return true;
 	}
 
+	@SuppressWarnings("deprecation")
 	@Override
 	protected String getModNameAgnos(String namespace) {
 		if (namespace.equals("c")) {

--- a/neoforge/src/main/java/dev/emi/emi/platform/neoforge/EmiAgnosNeoForge.java
+++ b/neoforge/src/main/java/dev/emi/emi/platform/neoforge/EmiAgnosNeoForge.java
@@ -11,6 +11,7 @@ import net.minecraft.item.PotionItem;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.neoforged.neoforge.client.ClientHooks;
 import net.neoforged.neoforge.common.CommonHooks;
+import org.apache.commons.lang3.text.WordUtils;
 import org.objectweb.asm.Type;
 
 import com.google.common.collect.Lists;
@@ -76,6 +77,10 @@ public class EmiAgnosNeoForge extends EmiAgnos {
 			return "Common";
 		}
 		Optional<? extends ModContainer> container = ModList.get().getModContainerById(namespace);
+		if (container.isPresent()) {
+			return container.get().getModInfo().getDisplayName();
+		}
+		container = ModList.get().getModContainerById(namespace.replace('_', '-'));
 		if (container.isPresent()) {
 			return container.get().getModInfo().getDisplayName();
 		}

--- a/neoforge/src/main/java/dev/emi/emi/platform/neoforge/EmiAgnosNeoForge.java
+++ b/neoforge/src/main/java/dev/emi/emi/platform/neoforge/EmiAgnosNeoForge.java
@@ -84,7 +84,7 @@ public class EmiAgnosNeoForge extends EmiAgnos {
 		if (container.isPresent()) {
 			return container.get().getModInfo().getDisplayName();
 		}
-		return namespace;
+		return WordUtils.capitalizeFully(namespace.replace('_', ' '));
 	}
 
 	@Override

--- a/neoforge/src/main/java/dev/emi/emi/platform/neoforge/EmiAgnosNeoForge.java
+++ b/neoforge/src/main/java/dev/emi/emi/platform/neoforge/EmiAgnosNeoForge.java
@@ -71,6 +71,7 @@ public class EmiAgnosNeoForge extends EmiAgnos {
 		return true;
 	}
 
+	@SuppressWarnings("deprecation")
 	@Override
 	protected String getModNameAgnos(String namespace) {
 		if (namespace.equals("c")) {


### PR DESCRIPTION
Attempts to get a mod container with ID `cool-mod` if the container with ID `cool_mod` doesn't exist.

If neither exist, falls back to `Cool Mod` instead of `cool_mod` using basic string formatting. 

Users that need IDs for commands can use F3+H.