### PR TITLE
Restores NeoForge AccessTransformer

### DIFF
--- a/neoforge/src/main/resources/META-INF/accesstransformer.cfg
+++ b/neoforge/src/main/resources/META-INF/accesstransformer.cfg
@@ -1,0 +1,10 @@
+public net.minecraft.world.item.alchemy.PotionBrewing$Mix
+
+public net.minecraft.world.item.alchemy.PotionBrewing POTION_MIXES
+public net.minecraft.world.item.alchemy.PotionBrewing CONTAINER_MIXES
+public net.minecraft.world.item.alchemy.PotionBrewing ALLOWED_CONTAINERS
+
+public net.minecraft.client.gui.screens.Screen addWidget(Lnet/minecraft/client/gui/components/events/GuiEventListener;)Lnet/minecraft/client/gui/components/events/GuiEventListener;
+
+public net.minecraft.client.gui.components.AbstractWidget x
+public net.minecraft.client.gui.components.AbstractWidget y


### PR DESCRIPTION
Restore deleted accesstransformer file, since archloom sadly does not convert the AW