### PR TITLE
allow category properties to set identifier sorting

### DIFF
--- a/xplat/src/main/java/dev/emi/emi/data/EmiData.java
+++ b/xplat/src/main/java/dev/emi/emi/data/EmiData.java
@@ -76,6 +76,9 @@ public class EmiData {
 									case "output_then_input":
 										props.sort = EmiRecipeSorting.compareOutputThenInput();
 										break;
+									case "identifier":
+										props.sort = EmiRecipeSorting.identifier();
+										break;
 								}
 							}
 						}


### PR DESCRIPTION
Identifier sorting exists but you can't set it via assets, so this fixes that. Adding that info to the table in https://github.com/emilyploszaj/emi/wiki/Recipe-Category-Properties would be good too.