### PR TITLE
fix #447 NPE

### DIFF
--- a/xplat/src/main/java/dev/emi/emi/screen/EmiScreenManager.java
+++ b/xplat/src/main/java/dev/emi/emi/screen/EmiScreenManager.java
@@ -857,6 +857,10 @@ public class EmiScreenManager {
 	}
 
 	public static void addWidgets(Screen screen) {
+		EmiScreenBase base = EmiScreenBase.getCurrent();
+		if (base == null) {
+			return;
+		}
 		forceRecalculate();
 		if (EmiConfig.centerSearchBar) {
 			search.x = (screen.width - 160) / 2;


### PR DESCRIPTION
Fixes #447

Turn on the HandRestock function of Tweakeroo, dig a block in survival mode, such as dirt, and then put it down immediately, it will cause a crash.