### PR TITLE
Make the EMI Server-Side component optional on Neoforge

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,6 +16,6 @@ fabric_api_version=0.91.3+1.20.4
 
 forge_version=1.20.4-49.0.9
 
-neoforge_version=20.4.76-beta
+neoforge_version=20.4.190
 
 jei_version=jei-1.20.2-fabric:16.0.0.28

--- a/neoforge/src/main/java/dev/emi/emi/platform/neoforge/EmiPacketHandler.java
+++ b/neoforge/src/main/java/dev/emi/emi/platform/neoforge/EmiPacketHandler.java
@@ -20,7 +20,7 @@ public class EmiPacketHandler {
     private static final Identifier ID_CHESS_SERVERBOUND = new Identifier("emi", "chess_c2s");
 
     public static void init(RegisterPayloadHandlerEvent event) {
-        var registrar = event.registrar("emi");
+        var registrar = event.registrar("emi").optional();
 
         registrar.play(EmiNetwork.FILL_RECIPE, makeReader(EmiNetwork.FILL_RECIPE, FillRecipeC2SPacket::new), EmiPacketHandler::handleServerbound);
         registrar.play(EmiNetwork.CREATE_ITEM, makeReader(EmiNetwork.CREATE_ITEM, CreateItemC2SPacket::new), EmiPacketHandler::handleServerbound);


### PR DESCRIPTION
I forgot to make the registrar optional, making the server-side component required on Neoforge. With this change, I was able to successfully connect to a Server that doesn't have EMI with just the client-side mod installed.

Also update to stable 1.20.4 Neoforge version.