### PR TITLE
Indicate on EmiStackInteraction that recipe is nullable

### DIFF
--- a/xplat/src/main/java/dev/emi/emi/api/stack/EmiStackInteraction.java
+++ b/xplat/src/main/java/dev/emi/emi/api/stack/EmiStackInteraction.java
@@ -1,6 +1,7 @@
 package dev.emi.emi.api.stack;
 
 import dev.emi.emi.api.recipe.EmiRecipe;
+import org.jetbrains.annotations.Nullable;
 
 public class EmiStackInteraction {
 	public static final EmiStackInteraction EMPTY = new EmiStackInteraction(EmiStack.EMPTY, null, false);
@@ -18,7 +19,7 @@ public class EmiStackInteraction {
 	 * @param clickable Whether this stack can be interacted with using a mouse for EMI functions.
 	 * 	For example, stacks in the sidebar can, but stacks in the inventory cannot.
 	 */
-	public EmiStackInteraction(EmiIngredient stack, EmiRecipe recipe, boolean clickable) {
+	public EmiStackInteraction(EmiIngredient stack, @Nullable EmiRecipe recipe, boolean clickable) {
 		this.stack = stack;
 		this.recipe = recipe;
 		this.clickable = clickable;
@@ -28,6 +29,7 @@ public class EmiStackInteraction {
 		return stack;
 	}
 
+	@Nullable
 	public EmiRecipe getRecipeContext() {
 		return recipe;
 	}


### PR DESCRIPTION
While unrelated to this change, I was bitten by EmiStackInteraction's shorter constructor setting clickable to `true` by default, since it overrides my slot default behavior :-)

In any case, since I now know that I need to use the full constructor to set clickable to false, I noticed that recipe is not actually marked as nullable, even though it is.