### PR TITLE
Cleanup build.gradle files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ allprojects {
 		compileOnly()
 	}
 
-	archivesBaseName = rootProject.archives_base_name
+	base.archivesName = rootProject.archives_base_name
 	ext.mavenVersion = "${rootProject.mod_version}"
 	if (System.getenv("RELEASE") == null) {
 		ext.mavenVersion += "-SNAPSHOT"
@@ -31,10 +31,10 @@ allprojects {
 		}
 	}
 
-	tasks.withType(JavaCompile) {
+	tasks.withType(JavaCompile).configureEach({
 		options.encoding = "UTF-8"
 		options.release = 17
-	}
+	})
 
 	java {
 		withSourcesJar()

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -81,7 +81,7 @@ processResources {
 
 def shadowJar = tasks.named('shadowJar', ShadowJar)
 
-shadowJar.configure { ShadowJar jar ->\
+shadowJar.configure { ShadowJar jar ->
 	jar.exclude "architectury.common.json"
 
 	jar.configurations = [project.configurations.shadowCommon]

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -1,3 +1,7 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import net.fabricmc.loom.task.RemapJarTask
+import net.fabricmc.loom.task.RemapSourcesJarTask
+
 buildscript {
 	repositories {
 		mavenCentral()
@@ -75,36 +79,41 @@ processResources {
 	}
 }
 
-shadowJar {
-	exclude "architectury.common.json"
+def shadowJar = tasks.named('shadowJar', ShadowJar)
 
-	configurations = [project.configurations.shadowCommon]
-	archiveClassifier = "dev-shadow"
+shadowJar.configure { ShadowJar jar ->\
+	jar.exclude "architectury.common.json"
+
+	jar.configurations = [project.configurations.shadowCommon]
+	jar.archiveClassifier = "dev-shadow"
 }
 
-remapJar {
-	injectAccessWidener = true
-	input.set shadowJar.archiveFile
+def remapJar = tasks.named('remapJar', RemapJarTask)
+
+remapJar.configure { RemapJarTask jar ->
 	dependsOn shadowJar
+	jar.inputFile.convention(shadowJar.flatMap {it.archiveFile })
+	jar.injectAccessWidener = true
 }
 
-sourcesJar {
-	def commonSources = project(":xplat").sourcesJar
+tasks.named('sourcesJar', Jar).configure { Jar jar ->
+	def commonSources = project(":xplat").tasks.named("sourcesJar", Jar)
 	dependsOn commonSources
-	from commonSources.archiveFile.map { zipTree(it) }
+	jar.from zipTree(commonSources.flatMap { it.archiveFile })
 }
 
-task filteredSourcesJar(type: Jar) {
+def filteredSourcesJar = tasks.register('filteredSourcesJar', Jar, {
 	archiveClassifier = 'filtered-sources'
+	def remapSourcesJar = tasks.named('remapSourcesJar', RemapSourcesJarTask)
 	dependsOn remapSourcesJar
-	from zipTree(remapSourcesJar.archivePath)
+	from zipTree(remapSourcesJar.flatMap { it.archiveFile })
 	exclude 'dev/emi/emi/jemi/**'
-}
+})
 
-task apiJar(type: Jar) {
+def apiJar = tasks.register('apiJar', Jar, {
 	archiveClassifier = 'api'
 	dependsOn remapJar
-	from zipTree(remapJar.archivePath)
+	from zipTree(remapJar.flatMap { it.archiveFile })
 	include 'fabric.mod.json'
 	include 'emi.mixins.json'
 	include 'emi-fabric.mixins.json'
@@ -116,10 +125,11 @@ task apiJar(type: Jar) {
 	exclude 'dev/emi/emi/api/stack/EmptyEmiStack**'
 	exclude 'dev/emi/emi/api/stack/TagEmiIngredient**'
 	exclude 'dev/emi/emi/api/stack/ListEmiIngredient**'
-}
+})
 
-build.dependsOn filteredSourcesJar
-build.dependsOn apiJar
+tasks.named("build").configure {
+	dependsOn(filteredSourcesJar, apiJar)
+}
 
 components.java {
 	withVariantsFromConfiguration(project.configurations.shadowRuntimeElements) {
@@ -129,7 +139,7 @@ components.java {
 
 publishing {
 	publications {
-		maven(MavenPublication) {
+		register('maven', MavenPublication) {
 			artifactId = "${rootProject.name}-${project.name}"
 			version = project.ext.mavenVersion
 			artifact(remapJar) {

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -1,3 +1,6 @@
+import net.fabricmc.loom.task.RemapJarTask
+import net.fabricmc.loom.task.RemapSourcesJarTask
+
 buildscript {
 	repositories {
 		mavenCentral()
@@ -83,27 +86,29 @@ shadowJar {
 }
 
 remapJar {
-	input.set shadowJar.archiveFile
+	inputFile.set shadowJar.archiveFile
 	dependsOn shadowJar
 }
 
-sourcesJar {
-	def commonSources = project(":xplat").sourcesJar
+tasks.named('sourcesJar', Jar).configure { Jar jar ->
+	def commonSources = project(":xplat").tasks.named("sourcesJar", Jar)
 	dependsOn commonSources
-	from commonSources.archiveFile.map { zipTree(it) }
+	jar.from zipTree(commonSources.flatMap { it.archiveFile })
 }
 
-task filteredSourcesJar(type: Jar) {
+def filteredSourcesJar = tasks.register('filteredSourcesJar', Jar, {
 	archiveClassifier = 'filtered-sources'
+	def remapSourcesJar = tasks.named('remapSourcesJar', RemapSourcesJarTask)
 	dependsOn remapSourcesJar
-	from zipTree(remapSourcesJar.archivePath)
+	from zipTree(remapSourcesJar.flatMap { it.archiveFile })
 	exclude 'dev/emi/emi/jemi/**'
-}
+})
 
-task apiJar(type: Jar) {
+def apiJar = tasks.register('apiJar', Jar, {
 	archiveClassifier = 'api'
+	def remapJar = tasks.named('remapJar', RemapJarTask)
 	dependsOn remapJar
-	from zipTree(remapJar.archivePath)
+	from zipTree(remapJar.flatMap { it.archiveFile })
 	include 'emi.mixins.json'
 	include 'emi-forge.mixins.json'
 	include 'emi.accesswidener'
@@ -114,10 +119,11 @@ task apiJar(type: Jar) {
 	exclude 'dev/emi/emi/api/stack/EmptyEmiStack**'
 	exclude 'dev/emi/emi/api/stack/TagEmiIngredient**'
 	exclude 'dev/emi/emi/api/stack/ListEmiIngredient**'
-}
+})
 
-build.dependsOn filteredSourcesJar
-build.dependsOn apiJar
+tasks.named("build").configure {
+	dependsOn(filteredSourcesJar, apiJar)
+}
 
 components.java {
 	withVariantsFromConfiguration(project.configurations.shadowRuntimeElements) {
@@ -127,7 +133,7 @@ components.java {
 
 publishing {
 	publications {
-		maven(MavenPublication) {
+		register('maven', MavenPublication) {
 			artifactId = "${rootProject.name}-${project.name}"
 			version = project.ext.mavenVersion
 			artifact(remapJar) {

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -1,3 +1,7 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import net.fabricmc.loom.task.RemapJarTask
+import net.fabricmc.loom.task.RemapSourcesJarTask
+
 buildscript {
 	repositories {
 		mavenCentral()
@@ -72,36 +76,45 @@ processResources {
 	}
 }
 
-shadowJar {
-	exclude "fabric.mod.json"
-	exclude "architectury.common.json"
+def shadowJar = tasks.named('shadowJar', ShadowJar)
 
-	configurations = [project.configurations.shadowCommon]
-	archiveClassifier = "dev-shadow"
+shadowJar.configure { ShadowJar jar ->
+	jar.exclude "fabric.mod.json"
+	jar.exclude "architectury.common.json"
+
+	jar.configurations = [project.configurations.shadowCommon]
+	jar.archiveClassifier = "dev-shadow"
 }
 
-remapJar {
-	input.set shadowJar.archiveFile
+def remapJar = tasks.named('remapJar', RemapJarTask)
+
+remapJar.configure { RemapJarTask jar ->
 	dependsOn shadowJar
+	jar.inputFile.convention(shadowJar.flatMap {it.archiveFile })
 }
 
-sourcesJar {
-	def commonSources = project(":xplat").sourcesJar
+def sourcesJar = tasks.named('sourcesJar', Jar)
+
+sourcesJar.configure { Jar jar ->
+	def commonSources = project(":xplat").tasks.named("sourcesJar", Jar)
 	dependsOn commonSources
-	from commonSources.archiveFile.map { zipTree(it) }
+	jar.from zipTree(commonSources.flatMap { it.archiveFile })
+	//TODO: Fix this in a better way that doesn't lead to stripping out the jemi sources
+	jar.exclude 'dev/emi/emi/jemi/**'
 }
 
-task filteredSourcesJar(type: Jar) {
+def filteredSourcesJar = tasks.register('filteredSourcesJar', Jar, {
 	archiveClassifier = 'filtered-sources'
+	def remapSourcesJar = tasks.named('remapSourcesJar', RemapSourcesJarTask)
 	dependsOn remapSourcesJar
-	from zipTree(remapSourcesJar.archivePath)
+	from zipTree(remapSourcesJar.flatMap { it.archiveFile })
 	exclude 'dev/emi/emi/jemi/**'
-}
+})
 
-task apiJar(type: Jar) {
+def apiJar = tasks.register('apiJar', Jar, {
 	archiveClassifier = 'api'
 	dependsOn remapJar
-	from zipTree(remapJar.archivePath)
+	from zipTree(remapJar.flatMap { it.archiveFile })
 	include 'emi.mixins.json'
 	include 'emi-neoforge.mixins.json'
 	include 'emi.accesswidener'
@@ -112,10 +125,11 @@ task apiJar(type: Jar) {
 	exclude 'dev/emi/emi/api/stack/EmptyEmiStack**'
 	exclude 'dev/emi/emi/api/stack/TagEmiIngredient**'
 	exclude 'dev/emi/emi/api/stack/ListEmiIngredient**'
-}
+})
 
-build.dependsOn filteredSourcesJar
-build.dependsOn apiJar
+tasks.named("build").configure {
+	dependsOn(filteredSourcesJar, apiJar)
+}
 
 components.java {
 	withVariantsFromConfiguration(project.configurations.shadowRuntimeElements) {
@@ -125,7 +139,7 @@ components.java {
 
 publishing {
 	publications {
-		maven(MavenPublication) {
+		register('maven', MavenPublication) {
 			artifactId = "${rootProject.name}-${project.name}"
 			version = project.ext.mavenVersion
 			artifact(remapJar) {

--- a/xplat/build.gradle
+++ b/xplat/build.gradle
@@ -1,3 +1,6 @@
+import net.fabricmc.loom.task.RemapJarTask
+import net.fabricmc.loom.task.RemapSourcesJarTask
+
 apply plugin: "dev.architectury.loom"
 
 architectury {
@@ -31,17 +34,19 @@ afterEvaluate {
 	configurations.default.extendsFrom = [configurations.namedElements]
 }
 
-task filteredSourcesJar(type: Jar) {
+def filteredSourcesJar = tasks.register('filteredSourcesJar', Jar, {
 	archiveClassifier = 'filtered-sources'
+	def remapSourcesJar = tasks.named('remapSourcesJar', RemapSourcesJarTask)
 	dependsOn remapSourcesJar
-	from zipTree(remapSourcesJar.archivePath)
+	from zipTree(remapSourcesJar.flatMap { it.archiveFile })
 	exclude 'dev/emi/emi/jemi/**'
-}
+})
 
-task apiJar(type: Jar) {
+def apiJar = tasks.register('apiJar', Jar, {
 	archiveClassifier = "api"
+	def remapJar = tasks.named('remapJar', RemapJarTask)
 	dependsOn remapJar
-	from zipTree(remapJar.archivePath)
+	from zipTree(remapJar.flatMap { it.archiveFile })
 	include 'fabric.mod.json'
 	include 'emi.mixins.json'
 	include 'emi.accesswidener'
@@ -52,14 +57,15 @@ task apiJar(type: Jar) {
 	exclude 'dev/emi/emi/api/stack/EmptyEmiStack**'
 	exclude 'dev/emi/emi/api/stack/TagEmiIngredient**'
 	exclude 'dev/emi/emi/api/stack/ListEmiIngredient**'
-}
+})
 
-build.dependsOn filteredSourcesJar
-build.dependsOn apiJar
+tasks.named("build").configure {
+	dependsOn(filteredSourcesJar, apiJar)
+}
 
 publishing {
 	publications {
-		maven(MavenPublication) {
+		register('maven', MavenPublication) {
 			artifactId = "${rootProject.name}-xplat-intermediary"
 			version = project.ext.mavenVersion
 			artifact(remapJar) {

--- a/xplat/mojmap/build.gradle
+++ b/xplat/mojmap/build.gradle
@@ -1,3 +1,7 @@
+import net.fabricmc.loom.api.mappings.layered.MappingsNamespace
+import net.fabricmc.loom.task.RemapJarTask
+import net.fabricmc.loom.task.RemapSourcesJarTask
+
 apply plugin: "dev.architectury.loom"
 
 evaluationDependsOn ':xplat'
@@ -7,50 +11,53 @@ dependencies {
 	mappings loom.officialMojangMappings()
 }
 
-task mojmapJar(type: net.fabricmc.loom.task.RemapJarTask) {
-	classpath.from loom.getMinecraftJarsCollection(net.fabricmc.loom.api.mappings.layered.MappingsNamespace.INTERMEDIARY)
-	dependsOn project(':xplat').remapJar
-	
-	inputFile = project(':xplat').remapJar.archiveFile
+def mojmapJar = tasks.register('mojmapJar', RemapJarTask, {
+	classpath.from loom.getMinecraftJarsCollection(MappingsNamespace.INTERMEDIARY)
+	def remapJar = project(':xplat').tasks.named('remapJar', RemapJarTask)
+	dependsOn remapJar
+
+	inputFile.convention(remapJar.flatMap {it.archiveFile })
 	sourceNamespace = 'intermediary'
 	targetNamespace = 'named'
 	
 	remapperIsolation = true
-}
+})
 
-task mojmapSourcesJar(type: net.fabricmc.loom.task.RemapSourcesJarTask) {
-	classpath.from loom.getMinecraftJarsCollection(net.fabricmc.loom.api.mappings.layered.MappingsNamespace.INTERMEDIARY)
-	dependsOn project(':xplat').filteredSourcesJar
+def mojmapSourcesJar = tasks.register('mojmapSourcesJar', RemapSourcesJarTask, {
+	classpath.from loom.getMinecraftJarsCollection(MappingsNamespace.INTERMEDIARY)
+	def filteredSourcesJar = project(':xplat').tasks.named('filteredSourcesJar', Jar)
+	dependsOn filteredSourcesJar
 	
 	archiveClassifier = 'sources'
-	
-	inputFile = project(':xplat').filteredSourcesJar.archiveFile
+
+	inputFile.convention(filteredSourcesJar.flatMap {it.archiveFile })
 	sourceNamespace = 'intermediary'
 	targetNamespace = 'named'
 	
 	remapperIsolation = true
-}
+})
 
-task mojmapApiJar(type: net.fabricmc.loom.task.RemapJarTask) {
-	classpath.from loom.getMinecraftJarsCollection(net.fabricmc.loom.api.mappings.layered.MappingsNamespace.INTERMEDIARY)
-	dependsOn project(':xplat').apiJar
+def mojmapApiJar = tasks.register('mojmapApiJar', RemapJarTask, {
+	classpath.from loom.getMinecraftJarsCollection(MappingsNamespace.INTERMEDIARY)
+	def apiJar = project(':xplat').tasks.named('apiJar', Jar)
+	dependsOn apiJar
 	
 	archiveClassifier = 'api'
-	
-	inputFile = project(':xplat').apiJar.archiveFile
+
+	inputFile.convention(apiJar.flatMap {it.archiveFile })
 	sourceNamespace = 'intermediary'
 	targetNamespace = 'named'
 	
 	remapperIsolation = true
-}
+})
 
-build.dependsOn mojmapJar
-build.dependsOn mojmapSourcesJar
-build.dependsOn mojmapApiJar
+tasks.named("build").configure {
+	dependsOn(mojmapJar, mojmapSourcesJar, mojmapApiJar)
+}
 
 publishing {
 	publications {
-		maven(MavenPublication) {
+		register('maven', MavenPublication) {
 			artifactId = "${rootProject.name}-xplat-mojmap"
 			version = project.ext.mavenVersion
 			artifact(mojmapJar) {


### PR DESCRIPTION
- Make use of lazy configuration which is the way of defining things that gradle has been slowly moving towards
- Fixes all gradle 9 warnings that are not just warnings of architectury loom as a plugin
- Fix source jars for neo not generating properly (#469). I am effectively just making both source jars for neo be filtered now instead of just the filtered one, as the remapper seems to crash when it encounters JEMI classes as JEI isn't on the classpath