### PR TITLE
Fix drag drop handler rendering at a further back z level than the item

### DIFF
--- a/xplat/src/main/java/dev/emi/emi/screen/EmiScreenManager.java
+++ b/xplat/src/main/java/dev/emi/emi/screen/EmiScreenManager.java
@@ -701,14 +701,11 @@ public class EmiScreenManager {
 					}
 				}
 			}
+			context.push();
+			context.matrices().translate(0, 0, 400);
 			EmiDragDropHandlers.render(base.screen(), draggedStack, context.raw(), mouseX, mouseY, delta);
-			MatrixStack view = RenderSystem.getModelViewStack();
-			view.push();
-			view.translate(0, 0, 400);
-			RenderSystem.applyModelViewMatrix();
 			draggedStack.render(context.raw(), mouseX - 8, mouseY - 8, delta, EmiIngredient.RENDER_ICON);
-			view.pop();
-			RenderSystem.applyModelViewMatrix();
+			context.pop();
 		}
 	}
 


### PR DESCRIPTION
For some of my screens, it appears that while the item does render above the screen, the green rendering of the drag drop renders too far back and is behind part of it. This fixes that problem, and also moves to using native matrix transforms rather than model view hacks, as items properly support those now.