### PR TITLE
Allow empty stacks to be used in packets again

### DIFF
--- a/xplat/src/main/java/dev/emi/emi/network/CreateItemC2SPacket.java
+++ b/xplat/src/main/java/dev/emi/emi/network/CreateItemC2SPacket.java
@@ -17,13 +17,13 @@ public class CreateItemC2SPacket implements EmiPacket {
 	}
 
 	public CreateItemC2SPacket(RegistryByteBuf buf) {
-		this(buf.readByte(), ItemStack.PACKET_CODEC.decode(buf));
+		this(buf.readByte(), ItemStack.OPTIONAL_PACKET_CODEC.decode(buf));
 	}
 
 	@Override
 	public void write(RegistryByteBuf buf) {
 		buf.writeByte(mode);
-		ItemStack.PACKET_CODEC.encode(buf, stack);
+		ItemStack.OPTIONAL_PACKET_CODEC.encode(buf, stack);
 	}
 
 	@Override

--- a/xplat/src/main/java/dev/emi/emi/network/FillRecipeC2SPacket.java
+++ b/xplat/src/main/java/dev/emi/emi/network/FillRecipeC2SPacket.java
@@ -52,7 +52,7 @@ public class FillRecipeC2SPacket implements EmiPacket {
 		int size = buf.readVarInt();
 		stacks = Lists.newArrayList();
 		for (int i = 0; i < size; i++) {
-			stacks.add(ItemStack.PACKET_CODEC.decode(buf));
+			stacks.add(ItemStack.OPTIONAL_PACKET_CODEC.decode(buf));
 		}
 	}
 
@@ -73,7 +73,7 @@ public class FillRecipeC2SPacket implements EmiPacket {
 		}
 		buf.writeVarInt(stacks.size());
 		for (ItemStack stack : stacks) {
-			ItemStack.PACKET_CODEC.encode(buf, stack);
+			ItemStack.OPTIONAL_PACKET_CODEC.encode(buf, stack);
 		}
 	}
 


### PR DESCRIPTION
Fixes #525. This is a regression from my port to 1.20.5. `ItemStack.PACKET_CODEC` does not permit empty stacks.