### PR TITLE
Avoid constructing ItemStack just to check tag membership

### DIFF
--- a/xplat/src/main/java/dev/emi/emi/registry/EmiStackList.java
+++ b/xplat/src/main/java/dev/emi/emi/registry/EmiStackList.java
@@ -157,7 +157,7 @@ public class EmiStackList {
 				if (s.getKey() instanceof Item i) {
 					if (i instanceof BlockItem bi && bi.getBlock().getDefaultState().isIn(BLOCK_HIDDEN)) {
 						return true;
-					} else if (s.getItemStack().isIn(ITEM_HIDDEN)) {
+					} else if (i.getRegistryEntry().isIn(ITEM_HIDDEN)) {
 						return true;
 					}
 				} else if (s.getKey() instanceof Fluid f) {


### PR DESCRIPTION
Since `getItemStack` is now rather complex (allocates an ItemStack), we may as well skip using it in spots where the stack is actually unnecessary.