### PR TITLE
Misc Jemi fixes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,4 +19,4 @@ forge_version=1.20.4-49.0.9
 neoforge_version=21.0.42-beta
 neoforge_yarn_patch=1.21+build.4
 
-jei_version=jei-1.21-fabric:19.0.0.14
+jei_version=jei-1.21-fabric:19.5.3.67

--- a/xplat/src/main/java/dev/emi/emi/jemi/JemiPlugin.java
+++ b/xplat/src/main/java/dev/emi/emi/jemi/JemiPlugin.java
@@ -97,7 +97,7 @@ public class JemiPlugin implements IModPlugin, EmiPlugin {
 					@SuppressWarnings("unchecked")
 					IIngredientTypeWithSubtypes<Object, Object> castedType = (IIngredientTypeWithSubtypes<Object, Object>) type;
 					SubtypeInterpreters interpreters = ((SubtypeRegistration) registration).getInterpreters();
-					return interpreters.contains(castedType, castedType.getBase(ingredient));
+					return interpreters.contains(castedType, ingredient);
 				};
 			}
 			return;

--- a/xplat/src/main/java/dev/emi/emi/jemi/JemiPlugin.java
+++ b/xplat/src/main/java/dev/emi/emi/jemi/JemiPlugin.java
@@ -69,6 +69,7 @@ import net.minecraft.client.util.math.Rect2i;
 import net.minecraft.fluid.Fluid;
 import net.minecraft.item.Item;
 import net.minecraft.recipe.CraftingRecipe;
+import net.minecraft.recipe.RecipeEntry;
 import net.minecraft.recipe.SpecialCraftingRecipe;
 import net.minecraft.screen.ScreenHandler;
 import net.minecraft.text.MutableText;
@@ -236,7 +237,7 @@ public class JemiPlugin implements IModPlugin, EmiPlugin {
 					if (type == RecipeTypes.INFORMATION) {
 						addInfoRecipes(registry, (IRecipeCategory<IJeiIngredientInfoRecipe>) c);
 					} else if (type == RecipeTypes.CRAFTING) {
-						addCraftingRecipes(registry, (IRecipeCategory<CraftingRecipe>) c);
+						addCraftingRecipes(registry, (IRecipeCategory<RecipeEntry<CraftingRecipe>>) c);
 					}
 					continue;
 				}
@@ -302,15 +303,15 @@ public class JemiPlugin implements IModPlugin, EmiPlugin {
 		}
 	}
 
-	private void addCraftingRecipes(EmiRegistry registry, IRecipeCategory<CraftingRecipe> category) {
+	private void addCraftingRecipes(EmiRegistry registry, IRecipeCategory<RecipeEntry<CraftingRecipe>> category) {
 		Set<Identifier> replaced = Sets.newHashSet();
 		Set<EmiRecipe> replacements = Sets.newHashSet();
-		List<CraftingRecipe> recipes = Stream.concat(
+		List<RecipeEntry<CraftingRecipe>> recipes = Stream.concat(
 			runtime.getRecipeManager().createRecipeLookup(category.getRecipeType()).includeHidden().get(),
-			registry.getRecipeManager().listAllOfType(net.minecraft.recipe.RecipeType.CRAFTING).stream().map(e -> e.value())
-				.filter(r -> r instanceof SpecialCraftingRecipe)
+			registry.getRecipeManager().listAllOfType(net.minecraft.recipe.RecipeType.CRAFTING).stream()
+				.filter(r -> r.value() instanceof SpecialCraftingRecipe)
 		).distinct().toList();
-		for (CraftingRecipe recipe : recipes) {
+		for (RecipeEntry<CraftingRecipe> recipe : recipes) {
 			try {
 				if (category.isHandled(recipe)) {
 					JemiRecipeLayoutBuilder builder = new JemiRecipeLayoutBuilder();

--- a/xplat/src/main/java/dev/emi/emi/jemi/JemiStackSerializer.java
+++ b/xplat/src/main/java/dev/emi/emi/jemi/JemiStackSerializer.java
@@ -31,9 +31,9 @@ public class JemiStackSerializer implements EmiIngredientSerializer<JemiStack> {
 			if (type == VanillaTypes.ITEM_STACK || type == JemiUtil.getFluidType()) {
 				continue;
 			}
-			Optional<?> opt = manager.getIngredientByUid(type, uid);
+			Optional<EmiStack> opt = manager.getTypedIngredientByUid(type, uid).map(JemiUtil::getStack);
 			if (opt.isPresent()) {
-				return JemiUtil.getStack(type, opt.get()).setAmount(amount);
+				return opt.get().setAmount(amount);
 			}
 		}
 		return EmiStack.EMPTY;

--- a/xplat/src/main/java/dev/emi/emi/jemi/runtime/JemiRecipesGui.java
+++ b/xplat/src/main/java/dev/emi/emi/jemi/runtime/JemiRecipesGui.java
@@ -14,6 +14,7 @@ import mezz.jei.api.ingredients.ITypedIngredient;
 import mezz.jei.api.recipe.IFocus;
 import mezz.jei.api.recipe.RecipeIngredientRole;
 import mezz.jei.api.recipe.RecipeType;
+import mezz.jei.api.recipe.category.IRecipeCategory;
 import mezz.jei.api.runtime.IRecipesGui;
 import net.minecraft.client.MinecraftClient;
 
@@ -43,6 +44,11 @@ public class JemiRecipesGui implements IRecipesGui {
 				}
 			}
 		}
+	}
+
+	@Override
+	public <T> void showRecipes(IRecipeCategory<T> recipeCategory, List<T> recipes, List<IFocus<?>> focuses) {
+		//TODO: Figure out how to implement
 	}
 
 	@Override

--- a/xplat/src/main/java/dev/emi/emi/jemi/runtime/JemiRecipesGui.java
+++ b/xplat/src/main/java/dev/emi/emi/jemi/runtime/JemiRecipesGui.java
@@ -48,7 +48,7 @@ public class JemiRecipesGui implements IRecipesGui {
 
 	@Override
 	public <T> void showRecipes(IRecipeCategory<T> recipeCategory, List<T> recipes, List<IFocus<?>> focuses) {
-		//TODO: Figure out how to implement
+		showTypes(List.of(recipeCategory.getRecipeType()));
 	}
 
 	@Override


### PR DESCRIPTION
- Fixed an exception I noticed in my log when processing certain recipes via `JemiPlugin#addCraftingRecipes`, as since `RecipeEntry`'s have been a thing the recipes jei tracks are `RecipeEntry<CraftingRecipe>` and not just `CraftingRecipe`. (The unchecked cast hid this error at compile time)
- Fixed a breaking change to the internals of `SubtypeInterpreters` that made `contains` take the ingredient instead of the base element
- Accounted for a deprecation for removal since JEI 19.1.0 in the `JemiStackSerializer` code (as the fix to subtype interpreters needs a version of `19.3.0` or higher)
- Declared the new method in our implementation of `IRecipeGui` so that if anyone calls it they won't get an abstract method not implemented exception (I forget the exact type of exception). Though I am not exactly sure how to implement the actual logic for the method, so would appreciate guidance (for now I just put a TODO).