### PR TITLE
Continue processing item groups if one throws an error

### DIFF
--- a/xplat/src/main/java/dev/emi/emi/registry/EmiStackList.java
+++ b/xplat/src/main/java/dev/emi/emi/registry/EmiStackList.java
@@ -83,8 +83,15 @@ public class EmiStackList {
 			Map<ItemGroup, Collection<ItemStack>> itemGroupToStacksMap = client.submit(() -> {
 				Map<ItemGroup, Collection<ItemStack>> map = new Reference2ReferenceOpenHashMap<>();
 				for (ItemGroup group : ItemGroups.getGroups()) {
-					group.updateEntries(context);
-					map.put(group, group.getSearchTabStacks());
+					String groupName = "null";
+					try {
+						groupName = group.getDisplayName().toString();
+						group.updateEntries(context);
+						map.put(group, group.getSearchTabStacks());
+					} catch(Exception e) {
+						EmiLog.error("Creative item group " + groupName + " threw while EMI was attempting to construct the index, items may be missing.");
+						EmiLog.error(e);
+					}
 				}
 				return map;
 			}).join();


### PR DESCRIPTION
#631 introduced a regression that causes loading to fail completely if one item group throws an exception; this PR restores the `try`/`catch` around individual groups.

Duplication of the `groupName` logic is not ideal but I didn't think it was worth more refactoring to avoid it.