### PR TITLE
Do not provide world context during off-thread tooltip retrieval

### DIFF
--- a/xplat/src/main/java/dev/emi/emi/api/stack/ItemEmiStack.java
+++ b/xplat/src/main/java/dev/emi/emi/api/stack/ItemEmiStack.java
@@ -159,7 +159,12 @@ public class ItemEmiStack extends EmiStack implements Batchable {
 
 	@Override
 	public List<Text> getTooltipText() {
-		return getItemStack().getTooltip(Item.TooltipContext.create(client.world), client.player, TooltipType.BASIC);
+		if (client.isOnThread()) {
+			return getItemStack().getTooltip(Item.TooltipContext.create(client.world), client.player, TooltipType.BASIC);
+		} else {
+			// Don't provide world or entity as context, as they are not thread safe
+			return getItemStack().getTooltip(Item.TooltipContext.create(client.world.getRegistryManager()), null, TooltipType.BASIC);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
The world/entity are not thread safe, so they should not be provided to `Item#getTooltip` calls from the search thread.

Note that the issue described in #709 mainly affects NeoForge, as it exposes the passed world to mods, while vanilla just uses it for the tick rate & registry managers. https://github.com/neoforged/NeoForge/blob/42023dc3e3284b7046791403db04649999389ba3/patches/net/minecraft/world/item/Item.java.patch#L221-L222