### PR TITLE
Search Box Suggestion Display Fix (1.20)

### DIFF
--- a/xplat/src/main/java/dev/emi/emi/screen/widget/EmiSearchWidget.java
+++ b/xplat/src/main/java/dev/emi/emi/screen/widget/EmiSearchWidget.java
@@ -80,15 +80,20 @@ public class EmiSearchWidget extends TextFieldWidget {
 		});
 		this.setChangedListener(string -> {
 			if (string.isEmpty()) {
-				this.setSuggestion(I18n.translate("emi.search"));
+				if (!this.isFocused()) {
+					this.setSuggestion(I18n.translate("emi.search"));
+				}
+				
 				EmiScreenManager.focusSearchSidebarType(EmiConfig.emptySearchSidebarFocus);
 			} else {
 				this.setSuggestion("");
 				EmiScreenManager.focusSearchSidebarType(EmiConfig.searchSidebarFocus);
 			}
+
 			Matcher matcher = EmiSearch.TOKENS.matcher(string);
 			List<Pair<Integer, Style>> styles = Lists.newArrayList();
 			int last = 0;
+			
 			while (matcher.find()) {
 				int start = matcher.start();
 				int end = matcher.end();
@@ -150,15 +155,22 @@ public class EmiSearchWidget extends TextFieldWidget {
 		if (!focused) {
 			searchHistoryIndex = 0;
 			String currentSearch = getText();
+			
 			if (!currentSearch.isBlank() && !currentSearch.isEmpty()) {
 				searchHistory.removeIf(String::isBlank);
 				searchHistory.remove(currentSearch);
 				searchHistory.add(0, currentSearch);
+				
 				if (searchHistory.size() > 36) {
 					searchHistory.remove(searchHistory.size() - 1);
 				}
+			} else {
+				this.setSuggestion(I18n.translate("emi.search"));
 			}
+		} else {
+			this.setSuggestion("");
 		}
+
 		isFocused = focused;
 		super.setFocused(focused);
 	}


### PR DESCRIPTION
This pull request fixes the placeholder/suggestion text (e.g. "Search EMI…") being visible together with the insertion point, overlapping each other. These changes make it so the `TextFieldWidget` used for EMI's search now hides its suggestion text whenever the field has focus, when the player wants to type. Once it loses focus, the suggestion is displayed again. Existing logic for hiding the suggestion when the text field has input is kept as-is.

I've also prepared this in basically the same way for `1.21` if you want me to open the pull request myself, though these changes are minor and you might be faster in your own process adding them.