### PR TITLE
Avoid O(n) List.contains calls in EmiTags

### DIFF
--- a/xplat/src/main/java/dev/emi/emi/registry/EmiTags.java
+++ b/xplat/src/main/java/dev/emi/emi/registry/EmiTags.java
@@ -106,7 +106,7 @@ public class EmiTags {
 		if (keys != null) {
 			for (TagKey<T> key : keys) {
 				List<T> values = (List<T>) TAG_CONTENTS.get(key);
-				map.keySet().removeAll(values);
+				values.forEach(map::remove);
 			}
 		} else {
 			keys = Lists.newArrayList();
@@ -117,7 +117,7 @@ public class EmiTags {
 					continue;
 				}
 				if (map.keySet().containsAll(values)) {
-					map.keySet().removeAll(values);
+					values.forEach(map::remove);
 					keys.add(key);
 				}
 				if (map.isEmpty()) {


### PR DESCRIPTION
Fixes an issue noticed on Discord, where the `removeAll` call here was invoking `contains` on the list for each element in the map. This approach should ensure the `contains` call always runs on the map instead (which is better since it has constant time lookups).