### PR TITLE
Add ability to disable tooltip indexing

### DIFF
--- a/xplat/src/main/java/dev/emi/emi/config/EmiConfig.java
+++ b/xplat/src/main/java/dev/emi/emi/config/EmiConfig.java
@@ -60,7 +60,7 @@ public class EmiConfig {
 	public static IndexSource indexSource = IndexSource.CREATIVE;
 
 	@ConfigGroup("general.search")
-	@Comment("Whether normal search queries should include the tooltip.")
+	@Comment("Whether normal search queries should include the tooltip. Requires index-tooltips to be enabled.")
 	@ConfigValue("general.search-tooltip-by-default")
 	public static boolean searchTooltipByDefault = true;
 
@@ -72,6 +72,12 @@ public class EmiConfig {
 	@Comment("Whether normal search queries should include the stack's tags.")
 	@ConfigValue("general.search-tags-by-default")
 	public static boolean searchTagsByDefault = false;
+
+	@ConfigGroup("general.search")
+	@Comment("Whether tooltip contents should be searchable at all. Disabling this can improve loading speed if"
+		+ " you have slow mods.")
+	@ConfigValue("general.index-tooltips")
+	public static boolean indexTooltips = true;
 
 	// UI
 	@Comment("Which action should be performed when clicking the recipe book.")

--- a/xplat/src/main/java/dev/emi/emi/search/EmiSearch.java
+++ b/xplat/src/main/java/dev/emi/emi/search/EmiSearch.java
@@ -71,7 +71,7 @@ public class EmiSearch {
 				if (name != null) {
 					names.add(searchStack, name.getString().toLowerCase());
 				}
-				List<Text> tooltip = stack.getTooltipText();
+				List<Text> tooltip = EmiConfig.indexTooltips ? stack.getTooltipText() : null;
 				if (tooltip != null) {
 					for (int i = 1; i < tooltip.size(); i++) {
 						Text text = tooltip.get(i);

--- a/xplat/src/main/resources/assets/emi/lang/en_us.json
+++ b/xplat/src/main/resources/assets/emi/lang/en_us.json
@@ -98,6 +98,7 @@
   "config.emi.general.cheat_mode": "Cheat Mode",
   "config.emi.general.help_level": "Help Level",
   "config.emi.general.index_source": "Index Source",
+  "config.emi.general.index_tooltips": "Index Tooltips",
   "config.emi.general.search_tooltip_by_default": "Search Tooltip by Default",
   "config.emi.general.search_mod_name_by_default": "Search Mod Name by Default",
   "config.emi.general.search_tags_by_default": "Search Tags by Default",


### PR DESCRIPTION
Reading the tooltips of modded items can be slow since many mods have relatively inefficient tooltip handlers. This PR adds an option to disable that, at the cost of preventing tooltips from being searched at all. The default is to still index tooltips.