### PR TITLE
Fix tag ingredient rendering in Fabulous

### DIFF
--- a/xplat/src/main/java/dev/emi/emi/api/stack/TagEmiIngredient.java
+++ b/xplat/src/main/java/dev/emi/emi/api/stack/TagEmiIngredient.java
@@ -130,7 +130,7 @@ public class TagEmiIngredient implements EmiIngredient {
 					.invokeRenderBakedItemModel(model,
 						ItemStack.EMPTY, LightmapTextureManager.MAX_LIGHT_COORDINATE, OverlayTexture.DEFAULT_UV, context.matrices(), 
 						ItemRenderer.getDirectItemGlintConsumer(immediate,
-							TexturedRenderLayers.getItemEntityTranslucentCull(), true, false));
+							TexturedRenderLayers.getEntityTranslucentCull(), true, false));
 				immediate.draw();
 				
 				if (!model.isSideLit()) {


### PR DESCRIPTION
Fixes #811 

Based on comparisons with vanilla's item rendering logic, the wrong render layer was being used, which I suspect caused the items to get drawn on the item entity framebuffer, rather than the main framebuffer.