### PR TITLE
Populate item groups in correct order

### DIFF
--- a/xplat/src/main/java/dev/emi/emi/registry/EmiStackList.java
+++ b/xplat/src/main/java/dev/emi/emi/registry/EmiStackList.java
@@ -94,7 +94,7 @@ public class EmiStackList {
 						EmiLog.error(e);
 					}
 				};
-				var itemGroups = ItemGroups.getGroups();
+				List<ItemGroup> itemGroups = ItemGroups.getGroups();
 				// Category item groups must be updated before non-category ones, otherwise the search group will
 				// read outdated item lists
 				itemGroups.stream().filter(g -> g.getType() == ItemGroup.Type.CATEGORY).forEach(itemGroupConsumer);


### PR DESCRIPTION
Since vanilla's search `ItemGroup` pulls data from the other item groups, we have to be careful to update the groups' entries in the correct order, otherwise the search group will persist outdated stacks from the previous reload. This change fixes #774.