### PR TITLE
Fix batcher drawing recipe categories in wrong spot on BoM screen

### DIFF
--- a/xplat/src/main/java/dev/emi/emi/screen/StackBatcher.java
+++ b/xplat/src/main/java/dev/emi/emi/screen/StackBatcher.java
@@ -132,7 +132,7 @@ public class StackBatcher {
 	public void render(Batchable batchable, DrawContext draw, int x, int y, float delta) {
 		if (!populated) {
 			try {
-				batchable.renderForBatch(batchable.isSideLit() ? imm : unlitFacade, draw, x-this.x, -y+this.y, z, delta);
+				batchable.renderForBatch(batchable.isSideLit() ? imm : unlitFacade, draw, x-this.x, y+this.y, z, delta);
 			} catch (Throwable t) {
 				if (EmiConfig.devMode) {
 					EmiLog.error("Batchable threw exception during batched rendering. See log for info");


### PR DESCRIPTION
Fixes #790. The `BoMScreen` is the only caller of this overload.