### PR TITLE
Only store incorrect IDs in dev mode

### DIFF
--- a/xplat/src/main/java/dev/emi/emi/registry/EmiRecipes.java
+++ b/xplat/src/main/java/dev/emi/emi/registry/EmiRecipes.java
@@ -180,7 +180,7 @@ public class EmiRecipes {
 						byId.put(id, recipe);
 					}
 
-					if (!id.getPath().startsWith("/") && !recipeIds.containsValue(id)) {
+					if (EmiConfig.devMode && !id.getPath().startsWith("/") && !recipeIds.containsValue(id)) {
 						incorrectIds.add(id);
 					}
 				}


### PR DESCRIPTION
The `incorrectIds` set was being populated despite only being used when `EmiConfig.devMode` is enabled. This took a noticeable amount of time in a modpack.

![image](https://github.com/user-attachments/assets/46134388-8e29-4dad-96bd-da0aa23afe6f)
