### PR TITLE
Add top search bar config

### DIFF
--- a/xplat/src/main/java/dev/emi/emi/config/EmiConfig.java
+++ b/xplat/src/main/java/dev/emi/emi/config/EmiConfig.java
@@ -117,6 +117,10 @@ public class EmiConfig {
 	@ConfigValue("ui.center-search-bar")
 	public static boolean centerSearchBar = true;
 
+	@Comment("Whether to have the search bar in the top of the screen, instead of to the bottom.")
+	@ConfigValue("ui.top-search-bar")
+	public static boolean topSearchBar = false;
+
 	@ConfigFilter("ui.search-sidebar-focus")
 	private static Predicate<SidebarType> searchSidebarFocusFilter = type -> {
 		return type != SidebarType.CHESS;

--- a/xplat/src/main/java/dev/emi/emi/screen/EmiScreenManager.java
+++ b/xplat/src/main/java/dev/emi/emi/screen/EmiScreenManager.java
@@ -926,6 +926,9 @@ public class EmiScreenManager {
 				search.setWidth(panels.get(0).space.tw * ENTRY_SIZE);
 			}
 		}
+		if (EmiConfig.topSearchBar) {
+			search.y = 2;
+		}
 		EmiPort.focus(search, false);
 		search.setVisible(EmiConfig.searchSidebar != SidebarSide.NONE);
 

--- a/xplat/src/main/resources/assets/emi/lang/en_us.json
+++ b/xplat/src/main/resources/assets/emi/lang/en_us.json
@@ -113,6 +113,7 @@
 
   "config.emi.ui.effect_location": "Effect Location",
   "config.emi.ui.center_search_bar": "Center Search Bar",
+  "config.emi.ui.top_search_bar": "Top Search Bar",
   "config.emi.ui.show_hover_overlay": "Show Hover Overlay",
   "config.emi.ui.append_mod_id": "Append Mod ID",
   "config.emi.ui.append_item_mod_id": "Append Item Mod ID",

--- a/xplat/src/main/resources/assets/emi/lang/es_es.json
+++ b/xplat/src/main/resources/assets/emi/lang/es_es.json
@@ -135,6 +135,7 @@
 
   "config.emi.ui.effect_location": "Ubicación de Efectos",
   "config.emi.ui.center_search_bar": "Centrar Barra de Búsqueda",
+  "config.emi.ui.top_search_bar": "Barra de Búsqueda Superior",
   "config.emi.ui.show_hover_overlay": "Resaltar Objeto Bajo el Cursor",
   "config.emi.ui.append_mod_id": "Mostrar ID del Mod",
   "config.emi.ui.append_item_mod_id": "Mostrar ID del Mod en Objeto",
@@ -144,6 +145,7 @@
 
   "config.emi.tooltip.ui.effect_location": "Determina dónde deben mostrarse los efectos en la interfaz.",
   "config.emi.tooltip.ui.center_search_bar": "Determina si la barra de búsqueda está centrada o en el lateral.",
+  "config.emi.tooltip.ui.top_search_bar": "Determina si la barra de búsqueda está en la parte superior o inferior de la pantalla.",
   "config.emi.tooltip.ui.show_hover_overlay": "Determina si se muestra un color de resalte en el objeto que está bajo el cursor.",
   "config.emi.tooltip.ui.append_mod_id": "Determina si se muestra el nombre del mod en la descripción del objeto.",
   "config.emi.tooltip.ui.append_item_mod_id": "Determina si se muestra el nombre del mod en la descripción del objeto, en caso de que otro mod tenga una función similar.",

--- a/xplat/src/main/resources/assets/emi/lang/fi_fi.json
+++ b/xplat/src/main/resources/assets/emi/lang/fi_fi.json
@@ -94,6 +94,7 @@
   
     "config.emi.ui.effect_location": "Vaikutusten sijainti",
     "config.emi.ui.center_search_bar": "Keskitä hakupankki",
+    "config.emi.ui.top_search_bar": "Yläreunan hakupalkki",
     "config.emi.ui.show_hover_overlay": "Näytä osoitetun peitekerros",
     "config.emi.ui.append_mod_id": "Lisää modi-ID",
     "config.emi.ui.append_item_mod_id": "Lisää tavaran modi-ID",

--- a/xplat/src/main/resources/assets/emi/lang/fr_fr.json
+++ b/xplat/src/main/resources/assets/emi/lang/fr_fr.json
@@ -122,8 +122,11 @@
   "config.emi.ui.move_effects": "Effets de potions",
   "config.emi.tooltip.ui.move_effects": "Change la position de\nla liste des effets de potions\n(à §6gauche§r, ou à §6droite§r)",
 
-  "config.emi.ui.center_search_bar": "Barre de recherche",
+  "config.emi.ui.center_search_bar": "Centre Barre de recherche",
   "config.emi.tooltip.ui.center_search_bar": "Change la position de\nla barre de recherche\n(au §6milieu§r, ou à §6droite§r)",
+
+  "config.emi.ui.top_search_bar": "Barre de recherche en haut",
+  "config.emi.tooltip.ui.top_search_bar": "Place la barre de recherche\nen haut de l'écran",
 
   "config.emi.ui.show_hover_overlay": "Coloration du choix",
   "config.emi.tooltip.ui.show_hover_overlay": "Permet d'afficher du gris\nquand votre souris passe\nau dessus d'un objet",

--- a/xplat/src/main/resources/assets/emi/lang/ja_jp.json
+++ b/xplat/src/main/resources/assets/emi/lang/ja_jp.json
@@ -134,6 +134,7 @@
 
   "config.emi.ui.effect_location": "効果の場所",
   "config.emi.ui.center_search_bar": "中央検索バー",
+  "config.emi.ui.top_search_bar": "上部検索バー",
   "config.emi.ui.show_hover_overlay": "ボタン判定の表示",
   "config.emi.ui.append_mod_id": "Mod IDを表示",
   "config.emi.ui.append_item_mod_id": "アイテムIDを表示",
@@ -143,6 +144,7 @@
 
   "config.emi.tooltip.ui.effect_location": "インベントリのどこにステータスエフェクトを表示するか。",
   "config.emi.tooltip.ui.center_search_bar": "検索バーを画面の横ではなく中央に表示するかどうか。",
+  "config.emi.tooltip.ui.top_search_bar": "検索バーを画面の下部ではなく上部に表示するかどうか。",
   "config.emi.tooltip.ui.show_hover_overlay": "スタックにカーソルを置いたときに灰色のオーバーレイを表示するかどうか。",
   "config.emi.tooltip.ui.append_mod_id": "ツールチップにMOD名を追加するかどうか。",
   "config.emi.tooltip.ui.append_item_mod_id": "他のMODが動作を提供する場合に備えて、アイテムのツールチップにMOD名を追加するかどうか。",

--- a/xplat/src/main/resources/assets/emi/lang/pt_br.json
+++ b/xplat/src/main/resources/assets/emi/lang/pt_br.json
@@ -143,6 +143,8 @@
   "config.emi.tooltip.ui.effect_location": "Determina onde os status de efeitos devem ser mostrados na tela.",
   "config.emi.ui.center_search_bar": "Centralizar Barra de Busca",
   "config.emi.tooltip.ui.center_search_bar": "Determina se a barra de busca deve ficar no centro da tela, ao invés de ficar na lateral.",
+  "config.emi.ui.top_search_bar": "Barra de Busca no Topo",
+  "config.emi.tooltip.ui.top_search_bar": "Determina se a barra de pesquisa é apresentada na parte superior do ecrã em vez de na parte inferior.",
   "config.emi.ui.show_hover_overlay": "Escurecer ao Passar o Mouse",
   "config.emi.tooltip.ui.show_hover_overlay": "Determina se o ícone de um item será escurecido ao passar o mouse por cima.",
   "config.emi.ui.append_mod_id": "Mostrar ID do Mod",

--- a/xplat/src/main/resources/assets/emi/lang/ru_ru.json
+++ b/xplat/src/main/resources/assets/emi/lang/ru_ru.json
@@ -116,6 +116,7 @@
 
   "config.emi.ui.effect_location": "Расположение эффектов",
   "config.emi.ui.center_search_bar": "Отцентровать поисковую строку",
+  "config.emi.ui.top_search_bar": "Поисковая строка сверху",
   "config.emi.ui.show_hover_overlay": "Показывать рамку при наведении",
   "config.emi.ui.append_mod_id": "Добавлять название мода",
   "config.emi.ui.append_item_mod_id": "Принудительно добавлять название мода",

--- a/xplat/src/main/resources/assets/emi/lang/tr_tr.json
+++ b/xplat/src/main/resources/assets/emi/lang/tr_tr.json
@@ -32,6 +32,7 @@
   
     "config.emi.ui.move_effects": "Hareket Efektleri",
     "config.emi.ui.center_search_bar": "Arama Kutucuğunu Ortala",
+    "config.emi.ui.top_search_bar": "Üstteki Arama Kutucuğu",
     "config.emi.ui.show_hover_overlay": "Üstünden Geçirme Kaplamasını Göster",
     "config.emi.ui.append_item_mod_id": "Eşya Mod ID'sini Ekle",
     "config.emi.ui.empty_search_craftable": "Boş aramayla Üretilebilenleri Göster",

--- a/xplat/src/main/resources/assets/emi/lang/zh_cn.json
+++ b/xplat/src/main/resources/assets/emi/lang/zh_cn.json
@@ -146,6 +146,8 @@
   "config.emi.tooltip.ui.effect_location": "状态效果在物品栏界面中的位置",
   "config.emi.ui.center_search_bar": "中置搜索框",
   "config.emi.tooltip.ui.center_search_bar": "移动搜索框至屏幕中间而非贴边",
+  "config.emi.ui.top_search_bar": "顶置搜索框",
+  "config.emi.tooltip.ui.top_search_bar": "移动搜索框至屏幕顶部而非底部",
   "config.emi.ui.show_hover_overlay": "显示选中遮罩",
   "config.emi.tooltip.ui.show_hover_overlay": "光标悬停于物品上时显示灰色遮罩",
   "config.emi.ui.append_mod_id": "显示物品所属模组",


### PR DESCRIPTION
Currently there is center search bar option in the config, but we can't have it on the top of the screen i guess.

Most localizations are done by machine translator, so need to be checked.