### PR TITLE
Improve time complexity of EmiRegistry.addEmiStackAfter

### DIFF
--- a/xplat/src/main/java/dev/emi/emi/registry/EmiRegistryImpl.java
+++ b/xplat/src/main/java/dev/emi/emi/registry/EmiRegistryImpl.java
@@ -1,5 +1,6 @@
 package dev.emi.emi.registry;
 
+import java.util.ListIterator;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -77,9 +78,11 @@ public class EmiRegistryImpl implements EmiRegistry {
 
 	@Override
 	public void addEmiStackAfter(EmiStack stack, Predicate<EmiStack> predicate) {
-		for (int i = 0; i < EmiStackList.stacks.size(); i++) {
-			if (predicate.test(EmiStackList.stacks.get(i))) {
-				EmiStackList.stacks.add(i + 1, stack);
+		ListIterator<EmiStack> listIterator = EmiStackList.stacks.listIterator();
+		while (listIterator.hasNext()) {
+			EmiStack candidate = listIterator.next();
+			if (predicate.test(candidate)) {
+				listIterator.add(stack);
 				return;
 			}
 		}


### PR DESCRIPTION
At the time of calling this, `EmiStackList.stacks` is still a linked list, so the time complexity of `get` scales with the provided index, resulting in the original loop being O(n^2). The new loop uses `ListIterator`, which allows traversing the linked list a single time and inserting directly after the desired node, rather than calling `List.add` which then requires another traversal through the list.

This improves the load time of Mahou Tsukai's EMI plugin from 19 seconds (before this change) to 60 milliseconds. However, the API should still be avoided in most cases, as its runtime cannot easily be improved beyond O(n).