### PR TITLE
Silently drop packets going to non-EMI clients

### DIFF
--- a/neoforge/src/main/java/dev/emi/emi/platform/neoforge/EmiNeoForge.java
+++ b/neoforge/src/main/java/dev/emi/emi/platform/neoforge/EmiNeoForge.java
@@ -19,7 +19,9 @@ public class EmiNeoForge {
 		EmiMain.init();
 		modEventBus.addListener(EmiPacketHandler::init);
 		EmiNetwork.initServer((player, packet) -> {
-			PacketDistributor.sendToPlayer(player, EmiPacketHandler.wrap(packet));
+			if (player.networkHandler.hasChannel(packet)) {
+				PacketDistributor.sendToPlayer(player, EmiPacketHandler.wrap(packet));
+			}
 		});
 		NeoForge.EVENT_BUS.addListener(this::registerCommands);
 		NeoForge.EVENT_BUS.addListener(this::playerConnect);


### PR DESCRIPTION
This fixes #889 as the ping packet is no longer sent to a client without that channel registered. Design-wise, I'm unsure if it's better to put this check at the call sites of `EmiNetwork.sendToClient` or to do it here where we actually send the packet. I opted for the current approach since it means a graceful fallback will occur for any packet, not just the ones the check is explicitly added to.