### PR TITLE
Fix stacks with a max size of 1 not being filled

### DIFF
--- a/xplat/src/main/java/dev/emi/emi/network/FillRecipeC2SPacket.java
+++ b/xplat/src/main/java/dev/emi/emi/network/FillRecipeC2SPacket.java
@@ -134,7 +134,7 @@ public class FillRecipeC2SPacket implements EmiPacket {
 						return;
 					} else {
 						Slot s = crafting.get(i);
-						if (s != null && s.canInsert(stack) && stack.getCount() <= s.getMaxItemCount() && stack.getCount() < stack.getMaxCount()) {
+						if (s != null && s.canInsert(stack) && stack.getCount() <= s.getMaxItemCount() && stack.getCount() <= stack.getMaxCount()) {
 							s.setStack(stack);
 						} else {
 							player.getInventory().offerOrDrop(stack);


### PR DESCRIPTION
After the check damageable tools, like GT tools, get filled correctly
