### PR TITLE
Deduplicate tag ingredient EmiStack lists

### DIFF
--- a/xplat/src/main/java/dev/emi/emi/api/stack/TagEmiIngredient.java
+++ b/xplat/src/main/java/dev/emi/emi/api/stack/TagEmiIngredient.java
@@ -79,6 +79,11 @@ public class TagEmiIngredient implements EmiIngredient {
 		return stacks;
 	}
 
+	@ApiStatus.Internal
+	public void setEmiStacks(List<EmiStack> stacks) {
+		this.stacks = stacks;
+	}
+
 	@Override
 	public long getAmount() {
 		return amount;

--- a/xplat/src/main/java/dev/emi/emi/registry/EmiRecipes.java
+++ b/xplat/src/main/java/dev/emi/emi/registry/EmiRecipes.java
@@ -8,6 +8,10 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import dev.emi.emi.api.stack.TagEmiIngredient;
+import dev.emi.emi.util.EmiStackListEqualityStrategy;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.ObjectOpenCustomHashSet;
 import org.jetbrains.annotations.Nullable;
 
 import com.google.common.collect.Iterables;
@@ -80,6 +84,20 @@ public class EmiRecipes {
 		}
 	}
 
+	private static void deduplicateTagInputs(List<EmiRecipe> recipes) {
+		ObjectOpenCustomHashSet<List<EmiStack>> stackLists = new ObjectOpenCustomHashSet<>(EmiStackListEqualityStrategy.INSTANCE);
+		for (EmiRecipe recipe : recipes) {
+			List<EmiIngredient> recipeInputs = recipe.getInputs();
+			for (EmiIngredient recipeInput : recipeInputs) {
+				if (recipeInput instanceof TagEmiIngredient tagIngredient) {
+					List<EmiStack> stackList = tagIngredient.getEmiStacks();
+					List<EmiStack> canonicalStackList = stackLists.addOrGet(stackList);
+					tagIngredient.setEmiStacks(canonicalStackList);
+				}
+			}
+		}
+	}
+
 	public static void bake() {
 		long start = System.currentTimeMillis();
 		recipes.addAll(EmiData.recipes.stream().map(r -> r.get()).toList());
@@ -103,6 +121,7 @@ public class EmiRecipes {
 			}
 			return true;
 		}).toList();
+		deduplicateTagInputs(filtered);
 		Map<EmiRecipeCategory, List<EmiIngredient>> filteredWorkstations = Maps.newHashMap();
 		for (Map.Entry<EmiRecipeCategory, List<EmiIngredient>> entry : workstations.entrySet()) {
 			List<EmiIngredient> w = entry.getValue().stream().filter(s -> !EmiHidden.isDisabled(s)).toList();

--- a/xplat/src/main/java/dev/emi/emi/util/EmiStackListEqualityStrategy.java
+++ b/xplat/src/main/java/dev/emi/emi/util/EmiStackListEqualityStrategy.java
@@ -1,0 +1,58 @@
+package dev.emi.emi.util;
+
+import dev.emi.emi.api.stack.Comparison;
+import dev.emi.emi.api.stack.EmiStack;
+import it.unimi.dsi.fastutil.Hash;
+
+import java.util.List;
+
+public final class EmiStackListEqualityStrategy implements Hash.Strategy<List<EmiStack>> {
+    public static final EmiStackListEqualityStrategy INSTANCE = new EmiStackListEqualityStrategy();
+
+    private EmiStackListEqualityStrategy() {}
+
+    @Override
+    public int hashCode(List<EmiStack> o) {
+        return o.hashCode();
+    }
+
+    private boolean stacksIdentical(EmiStack a, EmiStack b) {
+        if (a == b) {
+            return true;
+        }
+        if (a == null || b == null) {
+            return false;
+        }
+        // Check regular properties like item/components first
+        if(!a.isEqual(b, Comparison.compareComponents())) {
+            return false;
+        }
+        // We only need to be more strict when comparing two stacks that are not empty
+        if(a.isEmpty()) {
+            return true;
+        }
+        return stacksIdentical(a.getRemainder(), b.getRemainder()) &&
+                a.getChance() == b.getChance() &&
+                a.getAmount() == b.getAmount();
+    }
+
+    @Override
+    public boolean equals(List<EmiStack> a, List<EmiStack> b) {
+        if(a == b) {
+            return true;
+        }
+        if(a == null || b == null) {
+            return false;
+        }
+        if (a.size() != b.size()) {
+            return false;
+        }
+        int size = a.size();
+        for (int i = 0; i < size; i++) {
+            if (!stacksIdentical(a.get(i), b.get(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
This will likely need some refinement before being merged; opening it now to collect feedback.

This PR implements deduplication of the underlying stack lists used by `TagEmiIngredient` after all recipes are constructed. Initial testing suggests it saves about 80MB of memory in Craftoria; gains should scale with packs containing larger tags that are used often. The `TagEmiIngredient` objects themselves are still duplicated, but their shallow size isn't the majority of memory usage from what I see.