### PR TITLE
fix invalid "invalid ID" errors

### DIFF
--- a/xplat/src/main/java/dev/emi/emi/registry/EmiRecipes.java
+++ b/xplat/src/main/java/dev/emi/emi/registry/EmiRecipes.java
@@ -36,6 +36,7 @@ import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenCustomHashMap;
 import it.unimi.dsi.fastutil.objects.ObjectArraySet;
+import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.resource.language.I18n;
 import net.minecraft.recipe.Recipe;
@@ -71,7 +72,7 @@ public class EmiRecipes {
 		MinecraftClient client = MinecraftClient.getInstance();
 		if (client.world != null) {
 			RecipeManager manager = client.world.getRecipeManager();
-			recipeIds = Maps.newIdentityHashMap();
+			recipeIds = new Reference2ObjectOpenHashMap<>();
 			if (manager != null) {
 				for (RecipeEntry<?> entry : manager.values()) {
 					recipeIds.put(entry.value(), entry.id());


### PR DESCRIPTION
Java's built in `IdentityHashMap` compares both keys *and values* by identity, which breaks mods that recreate the recipe ID for their EMI displays (it logs an invalid id error for every single recipe in GT.)
I fixed it by using a FastUtil `Reference2ObjectOpenHashMap` instead, which compares keys by reference and values with `equals()`.

This might slow the recipe loading down a bit, I'm not quite sure. If it's too slow, I'll implement something different on my end.