### PR TITLE
Nonexistent recipes with enchanted books in anvil menu

### DIFF
--- a/fabric/src/main/java/dev/emi/emi/platform/fabric/EmiAgnosFabric.java
+++ b/fabric/src/main/java/dev/emi/emi/platform/fabric/EmiAgnosFabric.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
 
+import net.minecraft.enchantment.Enchantment;
 import org.apache.commons.lang3.text.WordUtils;
 
 import com.google.common.collect.Lists;
@@ -254,5 +255,10 @@ public class EmiAgnosFabric extends EmiAgnos {
 	@Override
 	protected BakedModel getBakedTagModelAgnos(Identifier id) {
 		return MinecraftClient.getInstance().getBakedModelManager().getModel(id);
+	}
+
+	@Override
+	protected boolean isEnchantableAgnos(ItemStack stack, Enchantment enchantment) {
+		return true;
 	}
 }

--- a/neoforge/src/main/java/dev/emi/emi/platform/neoforge/EmiAgnosNeoForge.java
+++ b/neoforge/src/main/java/dev/emi/emi/platform/neoforge/EmiAgnosNeoForge.java
@@ -326,6 +326,6 @@ public class EmiAgnosNeoForge extends EmiAgnos {
 	protected boolean isEnchantableAgnos(ItemStack stack, Enchantment enchantment) {
 		ItemStack enchantedBook = new ItemStack(Items.ENCHANTED_BOOK);
 		enchantedBook.addEnchantment(RegistryEntry.of(enchantment), enchantment.getMaxLevel());
-		return super.isEnchantableAgnos(stack, enchantment) && stack.isBookEnchantable(enchantedBook);
+		return stack.isBookEnchantable(enchantedBook);
 	}
 }

--- a/neoforge/src/main/java/dev/emi/emi/platform/neoforge/EmiAgnosNeoForge.java
+++ b/neoforge/src/main/java/dev/emi/emi/platform/neoforge/EmiAgnosNeoForge.java
@@ -14,7 +14,6 @@ import net.minecraft.item.Items;
 import net.minecraft.item.PotionItem;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.neoforged.neoforge.client.ClientHooks;
-import net.neoforged.neoforge.common.CommonHooks;
 import org.apache.commons.lang3.text.WordUtils;
 import org.objectweb.asm.Type;
 
@@ -47,7 +46,6 @@ import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.fluid.Fluid;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NbtCompound;
 import net.minecraft.potion.Potion;
 import net.minecraft.potion.Potions;
 import net.minecraft.recipe.BrewingRecipeRegistry;
@@ -328,6 +326,6 @@ public class EmiAgnosNeoForge extends EmiAgnos {
 	protected boolean isEnchantableAgnos(ItemStack stack, Enchantment enchantment) {
 		ItemStack enchantedBook = new ItemStack(Items.ENCHANTED_BOOK);
 		enchantedBook.addEnchantment(RegistryEntry.of(enchantment), enchantment.getMaxLevel());
-		return super.isEnchantableAgnos(stack, enchantment) && stack.getItem().isEnchantable(stack) && stack.isBookEnchantable(enchantedBook);
+		return super.isEnchantableAgnos(stack, enchantment) && stack.isBookEnchantable(enchantedBook);
 	}
 }

--- a/neoforge/src/main/java/dev/emi/emi/platform/neoforge/EmiAgnosNeoForge.java
+++ b/neoforge/src/main/java/dev/emi/emi/platform/neoforge/EmiAgnosNeoForge.java
@@ -9,6 +9,8 @@ import java.util.stream.Stream;
 
 import dev.emi.emi.mixin.accessor.BrewingRecipeRegistryAccessor;
 import net.minecraft.component.ComponentChanges;
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.item.Items;
 import net.minecraft.item.PotionItem;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.neoforged.neoforge.client.ClientHooks;
@@ -320,5 +322,12 @@ public class EmiAgnosNeoForge extends EmiAgnos {
 	@Override
 	protected BakedModel getBakedTagModelAgnos(Identifier id) {
 		return MinecraftClient.getInstance().getBakedModelManager().getModel(new ModelIdentifier(id, ModelIdentifier.STANDALONE_VARIANT));
+	}
+
+	@Override
+	protected boolean isEnchantableAgnos(ItemStack stack, Enchantment enchantment) {
+		ItemStack enchantedBook = new ItemStack(Items.ENCHANTED_BOOK);
+		enchantedBook.addEnchantment(RegistryEntry.of(enchantment), enchantment.getMaxLevel());
+		return super.isEnchantableAgnos(stack, enchantment) && stack.getItem().isEnchantable(stack) && stack.isBookEnchantable(enchantedBook);
 	}
 }

--- a/xplat/src/main/java/dev/emi/emi/VanillaPlugin.java
+++ b/xplat/src/main/java/dev/emi/emi/VanillaPlugin.java
@@ -520,7 +520,7 @@ public class VanillaPlugin implements EmiPlugin {
 						synthetic("anvil/enchanting", EmiUtil.subId(i) + "/" + EmiUtil.subId(EmiPort.getEnchantmentRegistry().getId(e)) + "/" + max)));
 				};
 				for (Enchantment e : targetedEnchantments) {
-					if (e.isAcceptableItem(defaultStack)) {
+					if (EmiAgnos.isEnchantable(defaultStack, e)) {
 						consumer.accept(e);
 						acceptableEnchantments++;
 					}

--- a/xplat/src/main/java/dev/emi/emi/VanillaPlugin.java
+++ b/xplat/src/main/java/dev/emi/emi/VanillaPlugin.java
@@ -520,7 +520,9 @@ public class VanillaPlugin implements EmiPlugin {
 						synthetic("anvil/enchanting", EmiUtil.subId(i) + "/" + EmiUtil.subId(EmiPort.getEnchantmentRegistry().getId(e)) + "/" + max)));
 				};
 				for (Enchantment e : targetedEnchantments) {
-					if (EmiAgnos.isEnchantable(defaultStack, e)) {
+					if (e.isAcceptableItem(defaultStack) && defaultStack.isEnchantable()
+							&& defaultStack.getItem().isEnchantable(defaultStack)
+							&& EmiAgnos.isEnchantable(defaultStack, e)) {
 						consumer.accept(e);
 						acceptableEnchantments++;
 					}

--- a/xplat/src/main/java/dev/emi/emi/platform/EmiAgnos.java
+++ b/xplat/src/main/java/dev/emi/emi/platform/EmiAgnos.java
@@ -159,7 +159,5 @@ public abstract class EmiAgnos {
 		return delegate.isEnchantableAgnos(stack, enchantment);
 	}
 
-	protected boolean isEnchantableAgnos(ItemStack stack, Enchantment enchantment) {
-		return enchantment.isAcceptableItem(stack) && stack.isEnchantable() && stack.getItem().isEnchantable(stack);
-	}
+	protected abstract boolean isEnchantableAgnos(ItemStack stack, Enchantment enchantment);
 }

--- a/xplat/src/main/java/dev/emi/emi/platform/EmiAgnos.java
+++ b/xplat/src/main/java/dev/emi/emi/platform/EmiAgnos.java
@@ -12,11 +12,10 @@ import net.minecraft.client.gui.tooltip.TooltipComponent;
 import net.minecraft.client.render.model.BakedModel;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.component.ComponentChanges;
-import net.minecraft.component.ComponentMap;
+import net.minecraft.enchantment.Enchantment;
 import net.minecraft.fluid.Fluid;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NbtCompound;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 
@@ -155,4 +154,12 @@ public abstract class EmiAgnos {
 	}
 
 	protected abstract BakedModel getBakedTagModelAgnos(Identifier id);
+
+	public static boolean isEnchantable(ItemStack stack, Enchantment enchantment) {
+		return delegate.isEnchantableAgnos(stack, enchantment);
+	}
+
+	protected boolean isEnchantableAgnos(ItemStack stack, Enchantment enchantment) {
+		return enchantment.isAcceptableItem(stack) && stack.isEnchantable();
+	}
 }

--- a/xplat/src/main/java/dev/emi/emi/platform/EmiAgnos.java
+++ b/xplat/src/main/java/dev/emi/emi/platform/EmiAgnos.java
@@ -160,6 +160,6 @@ public abstract class EmiAgnos {
 	}
 
 	protected boolean isEnchantableAgnos(ItemStack stack, Enchantment enchantment) {
-		return enchantment.isAcceptableItem(stack) && stack.isEnchantable();
+		return enchantment.isAcceptableItem(stack) && stack.isEnchantable() && stack.getItem().isEnchantable(stack);
 	}
 }


### PR DESCRIPTION
Fix a bug where combining an item with an enchanted book in the anvil menu generated nonexistent recipes in survival mode.