### PR TITLE
Better support for opening EMI screens from non-handled screens

### DIFF
--- a/xplat/src/main/java/dev/emi/emi/api/EmiApi.java
+++ b/xplat/src/main/java/dev/emi/emi/api/EmiApi.java
@@ -107,10 +107,10 @@ public class EmiApi {
 		Screen s = client.currentScreen;
 		if (s instanceof HandledScreen<?> hs) {
 			return hs;
-		} else if (s instanceof RecipeScreen rs) {
-			return rs.old;
-		} else if (s instanceof BoMScreen bs) {
-			return bs.old;
+		} else if (s instanceof RecipeScreen rs && rs.old instanceof HandledScreen<?> hs) {
+			return hs;
+		} else if (s instanceof BoMScreen bs && bs.old instanceof HandledScreen<?> hs) {
+			return hs;
 		}
 		return null;
 	}
@@ -243,13 +243,7 @@ public class EmiApi {
 			.collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()));
 		if (!recipes.isEmpty()) {
 			EmiSidebars.lookup(stack);
-			if (getHandledScreen() == null) {
-				client.setScreen(new InventoryScreen(client.player));
-			}
-			if (client.currentScreen instanceof HandledScreen<?> hs) {
-				push();
-				client.setScreen(new RecipeScreen(hs, recipes));
-			} else if (client.currentScreen instanceof BoMScreen bs) {
+			if (client.currentScreen instanceof BoMScreen bs) {
 				push();
 				client.setScreen(new RecipeScreen(bs.old, recipes));
 			} else if (client.currentScreen instanceof RecipeScreen rs) {
@@ -257,6 +251,9 @@ public class EmiApi {
 				RecipeScreen n = new RecipeScreen(rs.old, recipes);
 				client.setScreen(n);
 				n.focusCategory(rs.getFocusedCategory());
+			} else {
+				push();
+				client.setScreen(new RecipeScreen(client.currentScreen, recipes));
 			}
 		}
 	}

--- a/xplat/src/main/java/dev/emi/emi/registry/EmiRecipeFiller.java
+++ b/xplat/src/main/java/dev/emi/emi/registry/EmiRecipeFiller.java
@@ -97,6 +97,7 @@ public class EmiRecipeFiller {
 
 	@SuppressWarnings("unchecked")
 	public static <T extends ScreenHandler> @Nullable EmiRecipeHandler<T> getFirstValidHandler(EmiRecipe recipe, HandledScreen<T> screen) {
+		if (screen == null) return null;
 		EmiRecipeHandler<T> ret = null;
 		for (EmiRecipeHandler<T> handler : getAllHandlers(screen)) {
 			if (handler.supportsRecipe(recipe)) {

--- a/xplat/src/main/java/dev/emi/emi/registry/EmiRecipeFiller.java
+++ b/xplat/src/main/java/dev/emi/emi/registry/EmiRecipeFiller.java
@@ -97,7 +97,9 @@ public class EmiRecipeFiller {
 
 	@SuppressWarnings("unchecked")
 	public static <T extends ScreenHandler> @Nullable EmiRecipeHandler<T> getFirstValidHandler(EmiRecipe recipe, HandledScreen<T> screen) {
-		if (screen == null) return null;
+		if (screen == null) {
+			return null;
+		}
 		EmiRecipeHandler<T> ret = null;
 		for (EmiRecipeHandler<T> handler : getAllHandlers(screen)) {
 			if (handler.supportsRecipe(recipe)) {

--- a/xplat/src/main/java/dev/emi/emi/screen/BoMScreen.java
+++ b/xplat/src/main/java/dev/emi/emi/screen/BoMScreen.java
@@ -48,7 +48,6 @@ import dev.emi.emi.screen.tooltip.RecipeTooltipComponent;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import net.minecraft.client.gui.tooltip.TooltipComponent;
 import net.minecraft.client.sound.PositionedSoundInstance;
 import net.minecraft.client.util.InputUtil;
@@ -74,13 +73,13 @@ public class BoMScreen extends Screen {
 	private List<Cost> costs = Lists.newArrayList();
 	private EmiPlayerInventory playerInv;
 	private boolean hasRemainders = false;;
-	public HandledScreen<?> old;
+	public Screen old;
 	private int nodeWidth = 0;
 	private int nodeHeight = 0;
 	private int lastMouseX, lastMouseY;
 	private double scrollAcc = 0;
 
-	public BoMScreen(HandledScreen<?> old) {
+	public BoMScreen(Screen old) {
 		super(EmiPort.translatable("screen.emi.recipe_tree"));
 		this.old = old;
 	}

--- a/xplat/src/main/java/dev/emi/emi/screen/RecipeScreen.java
+++ b/xplat/src/main/java/dev/emi/emi/screen/RecipeScreen.java
@@ -47,7 +47,7 @@ public class RecipeScreen extends Screen {
 	private static final Identifier TEXTURE = EmiPort.id("emi", "textures/gui/background.png");
 	public static @Nullable EmiIngredient resolve = null;
 	private Map<EmiRecipeCategory, List<EmiRecipe>> recipes;
-	public HandledScreen<?> old;
+	public Screen old;
 	private List<RecipeTab> tabs = Lists.newArrayList();
 	private int tabPageSize = 6;
 	private int tabPage = 0, tab = 0, page = 0;
@@ -63,7 +63,7 @@ public class RecipeScreen extends Screen {
 	int x = (this.width - backgroundWidth) / 2;
 	int y = (this.height - backgroundHeight) / 2;
 
-	public RecipeScreen(HandledScreen<?> old, Map<EmiRecipeCategory, List<EmiRecipe>> recipes) {
+	public RecipeScreen(Screen old, Map<EmiRecipeCategory, List<EmiRecipe>> recipes) {
 		super(EmiPort.translatable("screen.emi.recipe"));
 		this.old = old;
 		arrows = List.of(


### PR DESCRIPTION
This fixes the behaviour where, upon closing the recipe screen that was opened from the FTB Quests screen, the client is returned to the inventory screen instead of the original quest screen.