### PR TITLE
Do not retain JEMI layout builder for every recipe

### DIFF
--- a/xplat/src/main/java/dev/emi/emi/jemi/JemiRecipe.java
+++ b/xplat/src/main/java/dev/emi/emi/jemi/JemiRecipe.java
@@ -44,7 +44,6 @@ public class JemiRecipe<T> implements EmiRecipe {
 	public Identifier originalId, id;
 	public IRecipeCategory<T> category;
 	public T recipe;
-	public JemiRecipeLayoutBuilder builder = new JemiRecipeLayoutBuilder();
 	public boolean allowTree = true;
 
 	public JemiRecipe(EmiRecipeCategory recipeCategory, IRecipeCategory<T> category, T recipe) {
@@ -55,6 +54,7 @@ public class JemiRecipe<T> implements EmiRecipe {
 		if (this.originalId != null) {
 			this.id = EmiPort.id("jei", "/" + EmiUtil.subId(this.originalId));
 		}
+		JemiRecipeLayoutBuilder builder = new JemiRecipeLayoutBuilder();
 		category.setRecipe(builder, recipe, JemiPlugin.runtime.getJeiHelpers().getFocusFactory().getEmptyFocusGroup());
 		for (JemiRecipeSlotBuilder jrsb : builder.slots) {
 			jrsb.acceptor.coerceStacks(jrsb.tooltipCallback, jrsb.renderers);


### PR DESCRIPTION
The `builder` field of `JemiRecipe` is only ever referenced during the constructor, and appears to just be used to compute the inputs/outputs/catalysts of the recipe. To actually render the recipe a new builder is created in `addWidgets`. Therefore it seems there's no need to retain this temporary initial builder in a field forever. Removing it substantially reduces the retained size of `JemiRecipe`s in a modpack.