### PR TITLE
Add ID to advanced fluid tooltips in Forge

### DIFF
--- a/forge/src/main/java/dev/emi/emi/platform/forge/EmiAgnosForge.java
+++ b/forge/src/main/java/dev/emi/emi/platform/forge/EmiAgnosForge.java
@@ -47,6 +47,7 @@ import net.minecraft.recipe.BrewingRecipeRegistry;
 import net.minecraft.recipe.Ingredient;
 import net.minecraft.screen.PlayerScreenHandler;
 import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
 import net.minecraftforge.client.ForgeHooksClient;
 import net.minecraftforge.client.extensions.common.IClientFluidTypeExtensions;
@@ -239,7 +240,14 @@ public class EmiAgnosForge extends EmiAgnos {
 
 	@Override
 	protected List<Text> getFluidTooltipAgnos(Fluid fluid, NbtCompound nbt) {
-		return List.of(getFluidName(fluid, nbt));
+		List<Text> tooltip = Lists.newArrayList();
+		tooltip.add(getFluidName(fluid, nbt));
+		MinecraftClient client = MinecraftClient.getInstance();
+		if (client.options.advancedItemTooltips) {
+			FluidEmiStack fes = new FluidEmiStack(fluid, nbt);
+			tooltip.add(EmiPort.literal(fes.getId().toString(), Formatting.DARK_GRAY));
+		}
+		return tooltip;
 	}
 
 	@Override


### PR DESCRIPTION
This backports the equivalent feature in NeoForge that was introduced in 2975b0647f663d0a903db71351289f6e678dd210.

***

reference merges into newer target versions can be found at:
+ <https://github.com/catgirl-v/emi/tree/topic/forge-advanced-tooltips-fluid-id/next/1.21> (trivial)

reference merges into older target versions can be found at:
+ <https://github.com/catgirl-v/emi/tree/topic/forge-advanced-tooltips-fluid-id/next/1.20.5> (trivial)
+ <https://github.com/catgirl-v/emi/tree/topic/forge-advanced-tooltips-fluid-id/next/1.20.4> (trivial)
+ <https://github.com/catgirl-v/emi/tree/topic/forge-advanced-tooltips-fluid-id/next/1.20.2> (trivial)
  
  newest target version with Forge. tested via `:forge:runClient`
+ <https://github.com/catgirl-v/emi/tree/topic/forge-advanced-tooltips-fluid-id/next/1.20> (trivial)
  
  tested via `:forge:runClient`
+ <https://github.com/catgirl-v/emi/tree/topic/forge-advanced-tooltips-fluid-id/next/1.19.4> (trivial)
+ <https://github.com/catgirl-v/emi/tree/topic/forge-advanced-tooltips-fluid-id/next/1.19.3> (trivial)
+ <https://github.com/catgirl-v/emi/tree/topic/forge-advanced-tooltips-fluid-id/next/1.19.2> (trivial)

builds are successful down to <https://github.com/catgirl-v/emi/tree/topic/forge-advanced-tooltips-fluid-id/next/1.19.2>.

also tested in:
+ <https://github.com/catgirl-v/emi/tree/1.20>
  
  includes catgirl-v's other downstream patches. tested via [`github:catgirl-v/pissfactory#pack-hardmode`](<https://github.com/catgirl-v/pissfactory>) (Monifactory downstream)