### PR TITLE
Add a keybind to pull the hovered favorite into the player's inventory

### DIFF
--- a/xplat/src/main/java/dev/emi/emi/api/EmiApi.java
+++ b/xplat/src/main/java/dev/emi/emi/api/EmiApi.java
@@ -123,7 +123,7 @@ public class EmiApi {
 		EmiRecipeManager manager = EmiApi.getRecipeManager();
 		setPages(manager.getCategories().stream().collect(Collectors.toMap(c -> c, c -> manager.getRecipes(c))), EmiStack.EMPTY);
 	}
-
+	
 	public static void displayRecipeCategory(EmiRecipeCategory category) {
 		setPages(Map.of(category, getRecipeManager().getRecipes(category)), EmiStack.EMPTY);
 	}

--- a/xplat/src/main/java/dev/emi/emi/api/EmiApi.java
+++ b/xplat/src/main/java/dev/emi/emi/api/EmiApi.java
@@ -25,6 +25,7 @@ import dev.emi.emi.recipe.EmiSyntheticIngredientRecipe;
 import dev.emi.emi.recipe.EmiTagRecipe;
 import dev.emi.emi.registry.EmiRecipes;
 import dev.emi.emi.registry.EmiStackList;
+import dev.emi.emi.registry.EmiStackPullers;
 import dev.emi.emi.runtime.EmiFavorite;
 import dev.emi.emi.runtime.EmiHistory;
 import dev.emi.emi.runtime.EmiSidebars;
@@ -175,53 +176,72 @@ public class EmiApi {
 			toPull = synthetic.amount;
 		}
 
-		HandledScreen<?> screen = EmiApi.getHandledScreen();
-		ScreenHandler screenHandler = screen.getScreenHandler();
-
 		MinecraftClient client = MinecraftClient.getInstance();
 		ClientPlayerInteractionManager manager = client.interactionManager;
 		PlayerEntity player = client.player;
+		ScreenHandler screenHandler = player.currentScreenHandler;
 
-		for (EmiStack emiStack : stack.getEmiStacks()) {
+		List<ItemStack> searchStacks = stack.getEmiStacks().stream().map(s -> s.getItemStack()).collect(Collectors.toList());
+
+		// Attempt to pull using any registered custom pullers, and stop on a successful pull
+		if (EmiStackPullers.attemptPull(screenHandler, searchStacks, toPull)) return;
+
+		for (ItemStack searchStack : searchStacks) {
 
 			// Sweep through all the non-player inventory slots
 			for (Slot inventorySlot : screenHandler.slots) {
-				if (inventorySlot.inventory instanceof PlayerInventory || !inventorySlot.hasStack()) continue;
-				if (!ItemStack.areItemsEqual(emiStack.getItemStack(), inventorySlot.getStack())) continue;
+				if (inventorySlot.inventory instanceof PlayerInventory || !inventorySlot.hasStack() || !inventorySlot.canTakeItems(player)) continue;
+				if (!ItemStack.areItemsEqual(searchStack, inventorySlot.getStack())) continue;
 
 				ItemStack fromStack = inventorySlot.getStack().copy();
+				int remaining = fromStack.getCount();
 
 				// And attempt to smoosh it into the player inventory
-				// Two loops, once to check combinable slots, then empty slots, to keep the player inventory tidy
-				for (int i = 0; i < 2; i++) {
-					for (Slot playerSlot : screenHandler.slots) {
-						if (!(playerSlot.inventory instanceof PlayerInventory)) continue;
+				for (Slot playerSlot : getQuickMoveDestinationSlots(screenHandler.slots, fromStack)) {
+					if (playerSlot.hasStack() && !ItemStack.areItemsAndComponentsEqual(fromStack, playerSlot.getStack())) continue;
 
-						if (i == 0 && !ItemStack.areItemsAndComponentsEqual(fromStack, playerSlot.getStack())) continue;
-						if (i == 1 && playerSlot.hasStack()) continue;
+					ItemStack playerStack = playerSlot.getStack();
 
-						manager.clickSlot(screenHandler.syncId, inventorySlot.id, 0, SlotActionType.PICKUP, player);
+					int maxTransfer = fromStack.getMaxCount() - playerStack.getCount();
+					int amountToTransfer = (int) Math.min(maxTransfer, toPull);
 
-						if (fromStack.getCount() <= toPull) {
-							toPull -= fromStack.getCount();
-							manager.clickSlot(screenHandler.syncId, playerSlot.id, 0, SlotActionType.PICKUP, player);
-						} else {
-							while (toPull > 0) {
-								manager.clickSlot(screenHandler.syncId, playerSlot.id, 1, SlotActionType.PICKUP, player);
-								toPull--;
-							}
+					manager.clickSlot(screenHandler.syncId, inventorySlot.id, 0, SlotActionType.PICKUP, player);
 
-							// put that thing back where it came from, or so help me...!
-							manager.clickSlot(screenHandler.syncId, inventorySlot.id, 0, SlotActionType.PICKUP, player);
+					if (remaining <= amountToTransfer) {
+						manager.clickSlot(screenHandler.syncId, playerSlot.id, 0, SlotActionType.PICKUP, player);
+						toPull -= remaining;
+						remaining = 0;
+					} else {
+						while (amountToTransfer > 0) {
+							manager.clickSlot(screenHandler.syncId, playerSlot.id, 1, SlotActionType.PICKUP, player);
+							toPull--;
+
+							amountToTransfer--;
+							remaining--;
 						}
 
-						if (toPull == 0) return;
-
-						break;
+						// put that thing back where it came from, or so help me...!
+						manager.clickSlot(screenHandler.syncId, inventorySlot.id, 0, SlotActionType.PICKUP, player);
 					}
+
+					if (toPull <= 0) return;
+					if (remaining <= 0) break;
 				}
 			}
 		}
+	}
+
+	private static List<Slot> getQuickMoveDestinationSlots(List<Slot> slots, ItemStack stackToMove) {
+		List<Slot> destinationSlots = Lists.newArrayList();
+		for (Slot candidateSlot : slots) {
+			if (candidateSlot.inventory instanceof PlayerInventory && candidateSlot.canInsert(stackToMove)) {
+				destinationSlots.add(candidateSlot);
+			}
+		}
+
+		// Sort such that we fill existing stacks first where possible
+		destinationSlots.sort((a, b) -> Boolean.compare(b.hasStack(), a.hasStack()));
+		return destinationSlots;
 	}
 
 	public static void viewRecipeTree() {

--- a/xplat/src/main/java/dev/emi/emi/api/EmiApi.java
+++ b/xplat/src/main/java/dev/emi/emi/api/EmiApi.java
@@ -35,6 +35,13 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import net.minecraft.client.gui.screen.ingame.InventoryScreen;
+import net.minecraft.client.network.ClientPlayerInteractionManager;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.screen.ScreenHandler;
+import net.minecraft.screen.slot.Slot;
+import net.minecraft.screen.slot.SlotActionType;
 
 public class EmiApi {
 	private static final MinecraftClient client = MinecraftClient.getInstance();
@@ -123,7 +130,7 @@ public class EmiApi {
 	public static void displayRecipe(EmiRecipe recipe) {
 		setPages(Map.of(recipe.getCategory(), List.of(recipe)), EmiStack.EMPTY);
 	}
-	
+
 	public static void displayRecipes(EmiIngredient stack) {
 		if (stack instanceof EmiFavorite fav) {
 			stack = fav.getStack();
@@ -152,6 +159,68 @@ public class EmiApi {
 						pruneUses(getRecipeManager().getRecipesByInput(zero), stack).stream(),
 						EmiRecipes.byWorkstation.getOrDefault(zero, List.of()).stream()).distinct().toList());
 			setPages(map, stack);
+		}
+	}
+
+	/**
+	 * Looks inside the currently open container and attempts to pull a matching item
+	 * into the player's inventory.
+	 * @param stack The item to search for and pull
+	 */
+	public static void pullItem(EmiIngredient stack) {
+		if (stack.isEmpty() || !(stack instanceof EmiFavorite)) return;
+
+		long toPull = 1;
+		if (stack instanceof EmiFavorite.Synthetic synthetic) {
+			toPull = synthetic.amount;
+		}
+
+		HandledScreen<?> screen = EmiApi.getHandledScreen();
+		ScreenHandler screenHandler = screen.getScreenHandler();
+
+		MinecraftClient client = MinecraftClient.getInstance();
+		ClientPlayerInteractionManager manager = client.interactionManager;
+		PlayerEntity player = client.player;
+
+		for (EmiStack emiStack : stack.getEmiStacks()) {
+
+			// Sweep through all the non-player inventory slots
+			for (Slot inventorySlot : screenHandler.slots) {
+				if (inventorySlot.inventory instanceof PlayerInventory || !inventorySlot.hasStack()) continue;
+				if (!ItemStack.areItemsEqual(emiStack.getItemStack(), inventorySlot.getStack())) continue;
+
+				ItemStack fromStack = inventorySlot.getStack().copy();
+
+				// And attempt to smoosh it into the player inventory
+				// Two loops, once to check combinable slots, then empty slots, to keep the player inventory tidy
+				for (int i = 0; i < 2; i++) {
+					for (Slot playerSlot : screenHandler.slots) {
+						if (!(playerSlot.inventory instanceof PlayerInventory)) continue;
+
+						if (i == 0 && !ItemStack.areItemsAndComponentsEqual(fromStack, playerSlot.getStack())) continue;
+						if (i == 1 && playerSlot.hasStack()) continue;
+
+						manager.clickSlot(screenHandler.syncId, inventorySlot.id, 0, SlotActionType.PICKUP, player);
+
+						if (fromStack.getCount() <= toPull) {
+							toPull -= fromStack.getCount();
+							manager.clickSlot(screenHandler.syncId, playerSlot.id, 0, SlotActionType.PICKUP, player);
+						} else {
+							while (toPull > 0) {
+								manager.clickSlot(screenHandler.syncId, playerSlot.id, 1, SlotActionType.PICKUP, player);
+								toPull--;
+							}
+
+							// put that thing back where it came from, or so help me...!
+							manager.clickSlot(screenHandler.syncId, inventorySlot.id, 0, SlotActionType.PICKUP, player);
+						}
+
+						if (toPull == 0) return;
+
+						break;
+					}
+				}
+			}
 		}
 	}
 

--- a/xplat/src/main/java/dev/emi/emi/api/EmiApi.java
+++ b/xplat/src/main/java/dev/emi/emi/api/EmiApi.java
@@ -123,7 +123,7 @@ public class EmiApi {
 		EmiRecipeManager manager = EmiApi.getRecipeManager();
 		setPages(manager.getCategories().stream().collect(Collectors.toMap(c -> c, c -> manager.getRecipes(c))), EmiStack.EMPTY);
 	}
-	
+
 	public static void displayRecipeCategory(EmiRecipeCategory category) {
 		setPages(Map.of(category, getRecipeManager().getRecipes(category)), EmiStack.EMPTY);
 	}
@@ -131,7 +131,7 @@ public class EmiApi {
 	public static void displayRecipe(EmiRecipe recipe) {
 		setPages(Map.of(recipe.getCategory(), List.of(recipe)), EmiStack.EMPTY);
 	}
-
+	
 	public static void displayRecipes(EmiIngredient stack) {
 		if (stack instanceof EmiFavorite fav) {
 			stack = fav.getStack();
@@ -171,7 +171,7 @@ public class EmiApi {
 	public static void pullItem(EmiIngredient stack) {
 		if (stack.isEmpty() || !(stack instanceof EmiFavorite)) return;
 
-		long toPull = 1;
+		long toPull = stack.getAmount();
 		if (stack instanceof EmiFavorite.Synthetic synthetic) {
 			toPull = synthetic.amount;
 		}
@@ -181,17 +181,17 @@ public class EmiApi {
 		PlayerEntity player = client.player;
 		ScreenHandler screenHandler = player.currentScreenHandler;
 
-		List<ItemStack> searchStacks = stack.getEmiStacks().stream().map(s -> s.getItemStack()).collect(Collectors.toList());
+		List<EmiStack> searchStacks = stack.getEmiStacks();
 
 		// Attempt to pull using any registered custom pullers, and stop on a successful pull
 		if (EmiStackPullers.attemptPull(screenHandler, searchStacks, toPull)) return;
 
-		for (ItemStack searchStack : searchStacks) {
+		for (EmiStack searchStack : searchStacks) {
 
 			// Sweep through all the non-player inventory slots
 			for (Slot inventorySlot : screenHandler.slots) {
 				if (inventorySlot.inventory instanceof PlayerInventory || !inventorySlot.hasStack() || !inventorySlot.canTakeItems(player)) continue;
-				if (!ItemStack.areItemsEqual(searchStack, inventorySlot.getStack())) continue;
+				if (!ItemStack.areItemsEqual(searchStack.getItemStack(), inventorySlot.getStack())) continue;
 
 				ItemStack fromStack = inventorySlot.getStack().copy();
 				int remaining = fromStack.getCount();

--- a/xplat/src/main/java/dev/emi/emi/api/EmiApi.java
+++ b/xplat/src/main/java/dev/emi/emi/api/EmiApi.java
@@ -10,6 +10,7 @@ import org.jetbrains.annotations.Nullable;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
+import dev.emi.emi.EmiPort;
 import dev.emi.emi.VanillaPlugin;
 import dev.emi.emi.api.recipe.EmiRecipe;
 import dev.emi.emi.api.recipe.EmiRecipeCategory;
@@ -39,7 +40,6 @@ import net.minecraft.client.gui.screen.ingame.InventoryScreen;
 import net.minecraft.client.network.ClientPlayerInteractionManager;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
-import net.minecraft.item.ItemStack;
 import net.minecraft.screen.ScreenHandler;
 import net.minecraft.screen.slot.Slot;
 import net.minecraft.screen.slot.SlotActionType;
@@ -191,19 +191,20 @@ public class EmiApi {
 			// Sweep through all the non-player inventory slots
 			for (Slot inventorySlot : screenHandler.slots) {
 				if (inventorySlot.inventory instanceof PlayerInventory || !inventorySlot.hasStack() || !inventorySlot.canTakeItems(player)) continue;
-				if (!ItemStack.areItemsEqual(searchStack.getItemStack(), inventorySlot.getStack())) continue;
+				
+				EmiStack fromStack = EmiStack.of(inventorySlot.getStack());
+				if (!searchStack.isEqual(fromStack)) continue;
 
-				ItemStack fromStack = inventorySlot.getStack().copy();
-				int remaining = fromStack.getCount();
+				long remaining = fromStack.getAmount();
 
 				// And attempt to smoosh it into the player inventory
 				for (Slot playerSlot : getQuickMoveDestinationSlots(screenHandler.slots, fromStack)) {
-					if (playerSlot.hasStack() && !ItemStack.areItemsAndComponentsEqual(fromStack, playerSlot.getStack())) continue;
+					if (playerSlot.hasStack() && !EmiStack.of(playerSlot.getStack()).isEqual(searchStack, EmiPort.compareStrict())) continue;
 
-					ItemStack playerStack = playerSlot.getStack();
+					EmiStack playerStack = EmiStack.of(playerSlot.getStack());
 
-					int maxTransfer = fromStack.getMaxCount() - playerStack.getCount();
-					int amountToTransfer = (int) Math.min(maxTransfer, toPull);
+					long maxTransfer = fromStack.getItemStack().getMaxCount() - playerStack.getAmount();
+					long amountToTransfer = Math.min(maxTransfer, toPull);
 
 					manager.clickSlot(screenHandler.syncId, inventorySlot.id, 0, SlotActionType.PICKUP, player);
 
@@ -231,10 +232,10 @@ public class EmiApi {
 		}
 	}
 
-	private static List<Slot> getQuickMoveDestinationSlots(List<Slot> slots, ItemStack stackToMove) {
+	private static List<Slot> getQuickMoveDestinationSlots(List<Slot> slots, EmiStack stackToMove) {
 		List<Slot> destinationSlots = Lists.newArrayList();
 		for (Slot candidateSlot : slots) {
-			if (candidateSlot.inventory instanceof PlayerInventory && candidateSlot.canInsert(stackToMove)) {
+			if (candidateSlot.inventory instanceof PlayerInventory && candidateSlot.canInsert(stackToMove.getItemStack())) {
 				destinationSlots.add(candidateSlot);
 			}
 		}

--- a/xplat/src/main/java/dev/emi/emi/api/EmiRegistry.java
+++ b/xplat/src/main/java/dev/emi/emi/api/EmiRegistry.java
@@ -34,7 +34,7 @@ public interface EmiRegistry {
 	 * @return The vanilla recipe manager, for iterating recipe types.
 	 */
 	RecipeManager getRecipeManager();
-	
+
 	/**
 	 * Adds a recipe category.
 	 * Recipes are organized based on recipe category.
@@ -141,6 +141,18 @@ public interface EmiRegistry {
 	 * Stack providers can inform EMI of EmiIngredients that are located on the screen.
 	 */
 	void addGenericStackProvider(EmiStackProvider<Screen> provider);
+
+	/**
+	 * Adds an EmiStackPuller to screens of a given class.
+	 * Stack pullers take items from the currently open container and place them on the player cursor.
+	 */
+	<T extends ScreenHandler> void addStackPuller(Class<T> clazz, EmiStackPuller<T> puller);
+
+	/**
+	 * Adds an EmiStackProvider to every screen.
+	 * Stack pullers take items from the currently open container and place them on the player cursor
+	 */
+	void addGenericStackPuller(EmiStackPuller<ScreenHandler> puller);
 
 	/**
 	 * Adds a default compraison method for a stack key.

--- a/xplat/src/main/java/dev/emi/emi/api/EmiRegistry.java
+++ b/xplat/src/main/java/dev/emi/emi/api/EmiRegistry.java
@@ -34,7 +34,7 @@ public interface EmiRegistry {
 	 * @return The vanilla recipe manager, for iterating recipe types.
 	 */
 	RecipeManager getRecipeManager();
-
+	
 	/**
 	 * Adds a recipe category.
 	 * Recipes are organized based on recipe category.
@@ -144,13 +144,13 @@ public interface EmiRegistry {
 
 	/**
 	 * Adds an EmiStackPuller to screens of a given class.
-	 * Stack pullers take items from the currently open container and place them on the player cursor.
+	 * Stack pullers take items from the currently open container and move them into the player's inventory.
 	 */
 	<T extends ScreenHandler> void addStackPuller(Class<T> clazz, EmiStackPuller<T> puller);
 
 	/**
 	 * Adds an EmiStackProvider to every screen.
-	 * Stack pullers take items from the currently open container and place them on the player cursor
+	 * Stack pullers take items from the currently open container and move them into the player's inventory.
 	 */
 	void addGenericStackPuller(EmiStackPuller<ScreenHandler> puller);
 

--- a/xplat/src/main/java/dev/emi/emi/api/EmiStackPuller.java
+++ b/xplat/src/main/java/dev/emi/emi/api/EmiStackPuller.java
@@ -2,7 +2,7 @@ package dev.emi.emi.api;
 
 import java.util.List;
 
-import net.minecraft.item.ItemStack;
+import dev.emi.emi.api.stack.EmiStack;
 import net.minecraft.screen.ScreenHandler;
 
 public interface EmiStackPuller<T extends ScreenHandler> {
@@ -13,6 +13,6 @@ public interface EmiStackPuller<T extends ScreenHandler> {
 	 * @param toPull The desired number of items to pull into the players inventory
 	 * @return whether or not the pull has been successfully handled by this, `true` stops execution of further handlers
 	 */
-	public boolean pullStack(T screenHandler, List<ItemStack> stacks, long toPull);
+	public boolean pullStack(T screenHandler, List<EmiStack> ingredients, long toPull);
 
 }

--- a/xplat/src/main/java/dev/emi/emi/api/EmiStackPuller.java
+++ b/xplat/src/main/java/dev/emi/emi/api/EmiStackPuller.java
@@ -1,0 +1,18 @@
+package dev.emi.emi.api;
+
+import java.util.List;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.screen.ScreenHandler;
+
+public interface EmiStackPuller<T extends ScreenHandler> {
+
+	/**
+	 * Pull stacks matching the given stack into the player inventory until toPull is reached or items run out
+	 * @param stacks All valid items for pulling, for tag favorites this will contain every item in the tag
+	 * @param toPull The desired number of items to pull into the players inventory
+	 * @return whether or not the pull has been successfully handled by this, `true` stops execution of further handlers
+	 */
+	public boolean pullStack(T screenHandler, List<ItemStack> stacks, long toPull);
+
+}

--- a/xplat/src/main/java/dev/emi/emi/config/EmiConfig.java
+++ b/xplat/src/main/java/dev/emi/emi/config/EmiConfig.java
@@ -206,7 +206,7 @@ public class EmiConfig {
 	@ConfigValue("ui.left-sidebar-subpanels")
 	public static SidebarSubpanels leftSidebarSubpanels = new SidebarSubpanels(List.of(
 	), SidebarSettings.LEFT);
-	
+
 	@Comment("How many columns and rows of ingredients to limit the left sidebar to")
 	@ConfigValue("ui.left-sidebar-size")
 	public static IntGroup leftSidebarSize = new IntGroup(
@@ -226,7 +226,7 @@ public class EmiConfig {
 	@Comment("Whether to render the header buttons and page count for the left sidebar")
 	@ConfigValue("ui.left-sidebar-header")
 	public static HeaderType leftSidebarHeader = HeaderType.VISIBLE;
-	
+
 	@ConfigGroupEnd
 	@Comment("Which theme to use for the left sidebar")
 	@ConfigValue("ui.left-sidebar-theme")
@@ -267,7 +267,7 @@ public class EmiConfig {
 	@Comment("Whether to render the header buttons and page count for the right sidebar")
 	@ConfigValue("ui.right-sidebar-header")
 	public static HeaderType rightSidebarHeader = HeaderType.VISIBLE;
-	
+
 	@ConfigGroupEnd
 	@Comment("Which theme to use for the right sidebar")
 	@ConfigValue("ui.right-sidebar-theme")
@@ -305,7 +305,7 @@ public class EmiConfig {
 	@Comment("Whether to render the header buttons and page count for the top sidebar")
 	@ConfigValue("ui.top-sidebar-header")
 	public static HeaderType topSidebarHeader = HeaderType.VISIBLE;
-	
+
 	@ConfigGroupEnd
 	@Comment("Which theme to use for the top sidebar")
 	@ConfigValue("ui.top-sidebar-theme")
@@ -343,7 +343,7 @@ public class EmiConfig {
 	@Comment("Whether to render the header buttons and page count for the bottom sidebar")
 	@ConfigValue("ui.bottom-sidebar-header")
 	public static HeaderType bottomSidebarHeader = HeaderType.VISIBLE;
-	
+
 	@ConfigGroupEnd
 	@Comment("Which theme to use for the bottom sidebar")
 	@ConfigValue("ui.bottom-sidebar-theme")
@@ -378,6 +378,10 @@ public class EmiConfig {
 	@ConfigValue("binds.favorite")
 	public static EmiBind favorite = new EmiBind("key.emi.favorite", GLFW.GLFW_KEY_A);
 
+	@Comment("Pull the stack from any currently open inventory that contains it.")
+	@ConfigValue("binds.pull-item")
+	public static EmiBind pullItem = new EmiBind("key.emi.pull_item", GLFW.GLFW_KEY_V);
+
 	@Comment("Set the default recipe for a given stack in the output of a recipe to that recipe.")
 	@ConfigValue("binds.default-stack")
 	public static EmiBind defaultStack = new EmiBind("key.emi.default_stack",
@@ -409,7 +413,7 @@ public class EmiConfig {
 	@Comment("When on a stack with an associated recipe:\n"
 		+ "Move ingredients for as many results as possible.")
 	@ConfigValue("binds.craft-all")
-	public static EmiBind craftAll = new EmiBind("key.emi.craft_all", 
+	public static EmiBind craftAll = new EmiBind("key.emi.craft_all",
 		new EmiBind.ModifiedKey(InputUtil.Type.MOUSE.createFromCode(0), EmiInput.SHIFT_MASK));
 
 	@Comment("When on a stack with an associated recipe:\n"
@@ -425,7 +429,7 @@ public class EmiConfig {
 	@Comment("When on a stack with an associated recipe:\n"
 		+ "Move ingredients for a single result and put in cursor if possible.")
 	@ConfigValue("binds.craft-one-to-cursor")
-	public static EmiBind craftOneToCursor = new EmiBind("key.emi.craft_one_to_cursor", 
+	public static EmiBind craftOneToCursor = new EmiBind("key.emi.craft_one_to_cursor",
 		new EmiBind.ModifiedKey(InputUtil.Type.MOUSE.createFromCode(0), EmiInput.CONTROL_MASK));
 
 	@ConfigGroupEnd
@@ -443,16 +447,16 @@ public class EmiConfig {
 	@ConfigValue("binds.cheat-stack-to-inventory")
 	public static EmiBind cheatStackToInventory = new EmiBind("key.emi.cheat_stack_to_inventory",
 		new EmiBind.ModifiedKey(InputUtil.Type.MOUSE.createFromCode(0), EmiInput.CONTROL_MASK));
-	
+
 	@Comment("Cheat in one of an item into the cursor.")
 	@ConfigValue("binds.cheat-one-to-cursor")
 	public static EmiBind cheatOneToCursor = new EmiBind("key.emi.cheat_one_to_cursor",
 		new EmiBind.ModifiedKey(InputUtil.Type.MOUSE.createFromCode(2), EmiInput.CONTROL_MASK));
-	
+
 	@Comment("Cheat in a stack of an item into the cursor.")
 	@ConfigValue("binds.cheat-stack-to-cursor")
 	public static EmiBind cheatStackToCursor = new EmiBind("key.emi.cheat_stack_to_cursor", InputUtil.UNKNOWN_KEY.getCode());
-	
+
 	@ConfigGroupEnd
 	@Comment("Delete the stack in the cursor when hovering the index")
 	@ConfigValue("binds.delete-cursor-stack")
@@ -472,7 +476,7 @@ public class EmiConfig {
 	@ConfigValue("binds.hide-stack-by-id")
 	public static EmiBind hideStackById = new EmiBind("key.emi.hide_stack_by_id",
 		new EmiBind.ModifiedKey(InputUtil.Type.MOUSE.createFromCode(0), EmiInput.CONTROL_MASK | EmiInput.SHIFT_MASK));
-	
+
 	// Dev
 	@Comment("Whether development functions should be enabled. Not recommended for general play.")
 	@ConfigValue("dev.dev-mode")
@@ -819,7 +823,7 @@ public class EmiConfig {
 		}
 		DEFAULT_CONFIG = getSavedConfig();
 	}
-	
+
 	@Target(ElementType.FIELD)
 	@Retention(RetentionPolicy.RUNTIME)
 	public static @interface ConfigValue {
@@ -831,19 +835,19 @@ public class EmiConfig {
 	public static @interface ConfigFilter {
 		public String value();
 	}
-	
+
 	@Target(ElementType.FIELD)
 	@Retention(RetentionPolicy.RUNTIME)
 	public static @interface Comment {
 		public String value();
 	}
-	
+
 	@Target(ElementType.FIELD)
 	@Retention(RetentionPolicy.RUNTIME)
 	public static @interface ConfigGroup {
 		public String value();
 	}
-	
+
 	@Target(ElementType.FIELD)
 	@Retention(RetentionPolicy.RUNTIME)
 	public static @interface ConfigGroupEnd {

--- a/xplat/src/main/java/dev/emi/emi/config/EmiConfig.java
+++ b/xplat/src/main/java/dev/emi/emi/config/EmiConfig.java
@@ -206,7 +206,7 @@ public class EmiConfig {
 	@ConfigValue("ui.left-sidebar-subpanels")
 	public static SidebarSubpanels leftSidebarSubpanels = new SidebarSubpanels(List.of(
 	), SidebarSettings.LEFT);
-
+	
 	@Comment("How many columns and rows of ingredients to limit the left sidebar to")
 	@ConfigValue("ui.left-sidebar-size")
 	public static IntGroup leftSidebarSize = new IntGroup(
@@ -267,7 +267,7 @@ public class EmiConfig {
 	@Comment("Whether to render the header buttons and page count for the right sidebar")
 	@ConfigValue("ui.right-sidebar-header")
 	public static HeaderType rightSidebarHeader = HeaderType.VISIBLE;
-
+	
 	@ConfigGroupEnd
 	@Comment("Which theme to use for the right sidebar")
 	@ConfigValue("ui.right-sidebar-theme")
@@ -305,7 +305,7 @@ public class EmiConfig {
 	@Comment("Whether to render the header buttons and page count for the top sidebar")
 	@ConfigValue("ui.top-sidebar-header")
 	public static HeaderType topSidebarHeader = HeaderType.VISIBLE;
-
+	
 	@ConfigGroupEnd
 	@Comment("Which theme to use for the top sidebar")
 	@ConfigValue("ui.top-sidebar-theme")
@@ -343,7 +343,7 @@ public class EmiConfig {
 	@Comment("Whether to render the header buttons and page count for the bottom sidebar")
 	@ConfigValue("ui.bottom-sidebar-header")
 	public static HeaderType bottomSidebarHeader = HeaderType.VISIBLE;
-
+	
 	@ConfigGroupEnd
 	@Comment("Which theme to use for the bottom sidebar")
 	@ConfigValue("ui.bottom-sidebar-theme")
@@ -413,7 +413,7 @@ public class EmiConfig {
 	@Comment("When on a stack with an associated recipe:\n"
 		+ "Move ingredients for as many results as possible.")
 	@ConfigValue("binds.craft-all")
-	public static EmiBind craftAll = new EmiBind("key.emi.craft_all",
+	public static EmiBind craftAll = new EmiBind("key.emi.craft_all", 
 		new EmiBind.ModifiedKey(InputUtil.Type.MOUSE.createFromCode(0), EmiInput.SHIFT_MASK));
 
 	@Comment("When on a stack with an associated recipe:\n"
@@ -429,7 +429,7 @@ public class EmiConfig {
 	@Comment("When on a stack with an associated recipe:\n"
 		+ "Move ingredients for a single result and put in cursor if possible.")
 	@ConfigValue("binds.craft-one-to-cursor")
-	public static EmiBind craftOneToCursor = new EmiBind("key.emi.craft_one_to_cursor",
+	public static EmiBind craftOneToCursor = new EmiBind("key.emi.craft_one_to_cursor", 
 		new EmiBind.ModifiedKey(InputUtil.Type.MOUSE.createFromCode(0), EmiInput.CONTROL_MASK));
 
 	@ConfigGroupEnd
@@ -447,16 +447,16 @@ public class EmiConfig {
 	@ConfigValue("binds.cheat-stack-to-inventory")
 	public static EmiBind cheatStackToInventory = new EmiBind("key.emi.cheat_stack_to_inventory",
 		new EmiBind.ModifiedKey(InputUtil.Type.MOUSE.createFromCode(0), EmiInput.CONTROL_MASK));
-
+	
 	@Comment("Cheat in one of an item into the cursor.")
 	@ConfigValue("binds.cheat-one-to-cursor")
 	public static EmiBind cheatOneToCursor = new EmiBind("key.emi.cheat_one_to_cursor",
 		new EmiBind.ModifiedKey(InputUtil.Type.MOUSE.createFromCode(2), EmiInput.CONTROL_MASK));
-
+	
 	@Comment("Cheat in a stack of an item into the cursor.")
 	@ConfigValue("binds.cheat-stack-to-cursor")
 	public static EmiBind cheatStackToCursor = new EmiBind("key.emi.cheat_stack_to_cursor", InputUtil.UNKNOWN_KEY.getCode());
-
+	
 	@ConfigGroupEnd
 	@Comment("Delete the stack in the cursor when hovering the index")
 	@ConfigValue("binds.delete-cursor-stack")
@@ -476,7 +476,7 @@ public class EmiConfig {
 	@ConfigValue("binds.hide-stack-by-id")
 	public static EmiBind hideStackById = new EmiBind("key.emi.hide_stack_by_id",
 		new EmiBind.ModifiedKey(InputUtil.Type.MOUSE.createFromCode(0), EmiInput.CONTROL_MASK | EmiInput.SHIFT_MASK));
-
+	
 	// Dev
 	@Comment("Whether development functions should be enabled. Not recommended for general play.")
 	@ConfigValue("dev.dev-mode")
@@ -823,7 +823,7 @@ public class EmiConfig {
 		}
 		DEFAULT_CONFIG = getSavedConfig();
 	}
-
+	
 	@Target(ElementType.FIELD)
 	@Retention(RetentionPolicy.RUNTIME)
 	public static @interface ConfigValue {
@@ -835,19 +835,19 @@ public class EmiConfig {
 	public static @interface ConfigFilter {
 		public String value();
 	}
-
+	
 	@Target(ElementType.FIELD)
 	@Retention(RetentionPolicy.RUNTIME)
 	public static @interface Comment {
 		public String value();
 	}
-
+	
 	@Target(ElementType.FIELD)
 	@Retention(RetentionPolicy.RUNTIME)
 	public static @interface ConfigGroup {
 		public String value();
 	}
-
+	
 	@Target(ElementType.FIELD)
 	@Retention(RetentionPolicy.RUNTIME)
 	public static @interface ConfigGroupEnd {

--- a/xplat/src/main/java/dev/emi/emi/registry/EmiRegistryImpl.java
+++ b/xplat/src/main/java/dev/emi/emi/registry/EmiRegistryImpl.java
@@ -12,6 +12,7 @@ import dev.emi.emi.api.EmiDragDropHandler;
 import dev.emi.emi.api.EmiExclusionArea;
 import dev.emi.emi.api.EmiRegistry;
 import dev.emi.emi.api.EmiStackProvider;
+import dev.emi.emi.api.EmiStackPuller;
 import dev.emi.emi.api.recipe.EmiRecipe;
 import dev.emi.emi.api.recipe.EmiRecipeCategory;
 import dev.emi.emi.api.recipe.EmiRecipeDecorator;
@@ -131,7 +132,17 @@ public class EmiRegistryImpl implements EmiRegistry {
 	public void addGenericStackProvider(EmiStackProvider<Screen> provider) {
 		EmiStackProviders.generic.add(provider);
 	}
-	
+
+	@Override
+	public <T extends ScreenHandler> void addStackPuller(Class<T> clazz, EmiStackPuller<T> puller) {
+		EmiStackPullers.fromClass.put(clazz, puller);
+	}
+
+	@Override
+	public void addGenericStackPuller(EmiStackPuller<ScreenHandler> puller) {
+		EmiStackPullers.generic.add(puller);
+	}
+
 	@Override
 	public <T extends ScreenHandler> void addRecipeHandler(ScreenHandlerType<T> type, EmiRecipeHandler<T> handler) {
 		EmiRecipeFiller.handlers.computeIfAbsent(type, (c) -> Lists.newArrayList()).add(handler);

--- a/xplat/src/main/java/dev/emi/emi/registry/EmiStackPullers.java
+++ b/xplat/src/main/java/dev/emi/emi/registry/EmiStackPullers.java
@@ -1,0 +1,37 @@
+package dev.emi.emi.registry;
+
+import java.util.Map;
+import java.util.List;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+import dev.emi.emi.api.EmiStackPuller;
+import net.minecraft.item.ItemStack;
+import net.minecraft.screen.ScreenHandler;
+
+public class EmiStackPullers {
+
+	public static Map<Class<? extends ScreenHandler>, EmiStackPuller<?>> fromClass = Maps.newHashMap();
+	public static List<EmiStackPuller<?>> generic = Lists.newArrayList();
+
+	public static void clear() {
+		fromClass.clear();
+		generic.clear();
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	public static boolean attemptPull(ScreenHandler screenHandler, List<ItemStack> stacks, long toPull) {
+		if (fromClass.containsKey(screenHandler.getClass())) {
+			EmiStackPuller puller = fromClass.get(screenHandler.getClass());
+			if (puller.pullStack(screenHandler, stacks, toPull)) return true;
+		}
+
+		for (EmiStackPuller puller : generic) {
+			if (puller.pullStack(screenHandler, stacks, toPull)) return true;
+		}
+
+		return false;
+	}
+
+}

--- a/xplat/src/main/java/dev/emi/emi/registry/EmiStackPullers.java
+++ b/xplat/src/main/java/dev/emi/emi/registry/EmiStackPullers.java
@@ -7,7 +7,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
 import dev.emi.emi.api.EmiStackPuller;
-import net.minecraft.item.ItemStack;
+import dev.emi.emi.api.stack.EmiStack;
 import net.minecraft.screen.ScreenHandler;
 
 public class EmiStackPullers {
@@ -21,7 +21,7 @@ public class EmiStackPullers {
 	}
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
-	public static boolean attemptPull(ScreenHandler screenHandler, List<ItemStack> stacks, long toPull) {
+	public static boolean attemptPull(ScreenHandler screenHandler, List<EmiStack> stacks, long toPull) {
 		if (fromClass.containsKey(screenHandler.getClass())) {
 			EmiStackPuller puller = fromClass.get(screenHandler.getClass());
 			if (puller.pullStack(screenHandler, stacks, toPull)) return true;

--- a/xplat/src/main/java/dev/emi/emi/runtime/EmiReloadManager.java
+++ b/xplat/src/main/java/dev/emi/emi/runtime/EmiReloadManager.java
@@ -77,7 +77,7 @@ public class EmiReloadManager {
 			}
 		}
 	}
-
+	
 	public static void reload() {
 		synchronized (EmiReloadManager.class) {
 			step(EmiPort.literal("Starting Reload"));
@@ -110,7 +110,7 @@ public class EmiReloadManager {
 	public static int getStatus() {
 		return status;
 	}
-
+	
 	private static class ReloadWorker implements Runnable {
 
 		@Override
@@ -151,7 +151,7 @@ public class EmiReloadManager {
 					List<EmiPluginContainer> plugins = Lists.newArrayList();
 					plugins.addAll(EmiAgnos.getPlugins().stream()
 						.sorted((a, b) -> Integer.compare(entrypointPriority(a), entrypointPriority(b))).toList());
-
+					
 					if (EmiAgnos.isModLoaded("jei")) {
 						plugins.add(new EmiPluginContainer(new JemiPlugin(), "jemi"));
 					}
@@ -182,7 +182,7 @@ public class EmiReloadManager {
 						continue;
 					}
 					EmiRegistry registry = new EmiRegistryImpl();
-
+					
 					for (EmiPluginContainer container : plugins) {
 						step(EmiPort.literal("Loading plugin from " + container.id()), 10_000);
 						long start = System.currentTimeMillis();

--- a/xplat/src/main/java/dev/emi/emi/runtime/EmiReloadManager.java
+++ b/xplat/src/main/java/dev/emi/emi/runtime/EmiReloadManager.java
@@ -24,6 +24,7 @@ import dev.emi.emi.registry.EmiRecipes;
 import dev.emi.emi.registry.EmiRegistryImpl;
 import dev.emi.emi.registry.EmiStackList;
 import dev.emi.emi.registry.EmiStackProviders;
+import dev.emi.emi.registry.EmiStackPullers;
 import dev.emi.emi.registry.EmiTags;
 import dev.emi.emi.screen.EmiScreenManager;
 import dev.emi.emi.search.EmiSearch;
@@ -76,7 +77,7 @@ public class EmiReloadManager {
 			}
 		}
 	}
-	
+
 	public static void reload() {
 		synchronized (EmiReloadManager.class) {
 			step(EmiPort.literal("Starting Reload"));
@@ -109,7 +110,7 @@ public class EmiReloadManager {
 	public static int getStatus() {
 		return status;
 	}
-	
+
 	private static class ReloadWorker implements Runnable {
 
 		@Override
@@ -130,6 +131,7 @@ public class EmiReloadManager {
 					EmiExclusionAreas.clear();
 					EmiDragDropHandlers.clear();
 					EmiStackProviders.clear();
+					EmiStackPullers.clear();
 					EmiRecipeFiller.clear();
 					EmiHidden.clear();
 					EmiTags.ADAPTERS_BY_CLASS.map().clear();
@@ -149,7 +151,7 @@ public class EmiReloadManager {
 					List<EmiPluginContainer> plugins = Lists.newArrayList();
 					plugins.addAll(EmiAgnos.getPlugins().stream()
 						.sorted((a, b) -> Integer.compare(entrypointPriority(a), entrypointPriority(b))).toList());
-					
+
 					if (EmiAgnos.isModLoaded("jei")) {
 						plugins.add(new EmiPluginContainer(new JemiPlugin(), "jemi"));
 					}
@@ -180,7 +182,7 @@ public class EmiReloadManager {
 						continue;
 					}
 					EmiRegistry registry = new EmiRegistryImpl();
-					
+
 					for (EmiPluginContainer container : plugins) {
 						step(EmiPort.literal("Loading plugin from " + container.id()), 10_000);
 						long start = System.currentTimeMillis();

--- a/xplat/src/main/java/dev/emi/emi/screen/EmiScreenManager.java
+++ b/xplat/src/main/java/dev/emi/emi/screen/EmiScreenManager.java
@@ -868,7 +868,7 @@ public class EmiScreenManager {
 			for (EmiFavorite.Synthetic fav : syntheticFavorites) {
 				synfavs.addAll(fav.getEmiStacks());
 			}
-			
+
 			try {
 				HandledScreen<?> hs = EmiApi.getHandledScreen();
 				for (EmiRecipeHandler handler : EmiRecipeFiller.getAllHandlers(hs)) {
@@ -1241,6 +1241,9 @@ public class EmiScreenManager {
 			} else if (function.apply(EmiConfig.viewUses)) {
 				EmiApi.displayUses(ingredient);
 				return true;
+			} else if (function.apply(EmiConfig.pullItem)) {
+				EmiApi.pullItem(ingredient);
+				return true;
 			} else if (function.apply(EmiConfig.favorite)) {
 				EmiFavorites.addFavorite(ingredient, stack.getRecipeContext());
 				repopulatePanels(SidebarType.FAVORITES);
@@ -1373,7 +1376,7 @@ public class EmiScreenManager {
 			return false;
 		}
 	}
-	
+
 	private static boolean deleteCursor(int mx, int my) {
 		if (client.currentScreen instanceof HandledScreen<?> handled) {
 			ItemStack cursor = handled.getScreenHandler().getCursorStack();

--- a/xplat/src/main/java/dev/emi/emi/screen/EmiScreenManager.java
+++ b/xplat/src/main/java/dev/emi/emi/screen/EmiScreenManager.java
@@ -868,7 +868,7 @@ public class EmiScreenManager {
 			for (EmiFavorite.Synthetic fav : syntheticFavorites) {
 				synfavs.addAll(fav.getEmiStacks());
 			}
-
+			
 			try {
 				HandledScreen<?> hs = EmiApi.getHandledScreen();
 				for (EmiRecipeHandler handler : EmiRecipeFiller.getAllHandlers(hs)) {
@@ -1376,7 +1376,7 @@ public class EmiScreenManager {
 			return false;
 		}
 	}
-
+	
 	private static boolean deleteCursor(int mx, int my) {
 		if (client.currentScreen instanceof HandledScreen<?> handled) {
 			ItemStack cursor = handled.getScreenHandler().getCursorStack();

--- a/xplat/src/main/resources/assets/emi/lang/en_us.json
+++ b/xplat/src/main/resources/assets/emi/lang/en_us.json
@@ -8,6 +8,7 @@
   "key.emi.clear_search": "Clear Search",
   "key.emi.view_recipes": "View Recipes",
   "key.emi.view_uses": "View Uses",
+  "key.emi.pull_item": "Pull Item",
   "key.emi.favorite": "Favorite",
   "key.emi.set_default": "Set Default",
   "key.emi.default_stack": "Default Stack",
@@ -262,7 +263,7 @@
   "tooltip.emi.bom.mode.view": "§6Viewing§r recipe tree",
   "tooltip.emi.bom.mode.craft": "§6Crafting§r recipe tree\nProgress will be shown in recipe tree\n§bSynthetic favorites§r added to sidebar",
   "tooltip.emi.bom.help": "The recipe tree shows the process and base cost of a recipe\nThe display can be panned and zoomed\n\nLeft click a node to choose a recipe to assign to it\nHold §6[shift]§r to automatically pick based on your inventory\n\nRight click a recipe node to fold it temporarily\nHold §6[shift]§r to clear the recipe\n\nThe initial tree state is controlled by default recipes\nA button next to recipes can set default recipe preferences\n\nThe toggle by total cost can be used to help craft a recipe tree\nWhile crafting, materials that need to be collected will be displayed\n§bSynthetic favorites§r will be added to the favorites sidebar that\nwill show incomplete steps and can be used to craft",
-  
+
   "tooltip.emi.fluid_interaction.basalt.soul_soil": "Below lava",
   "tooltip.emi.fluid_interaction.basalt.blue_ice": "Adjacent to lava",
 
@@ -326,7 +327,7 @@
   "emi.category.emi.fuel": "Fuel",
   "emi.category.emi.composting": "Composting",
   "emi.category.emi.info": "Info",
-  
+
   "emi.category.emi.tag": "Tags",
   "emi.category.emi.ingredient": "Ingredients",
 
@@ -528,7 +529,7 @@
   "tag.item.c.ores_in_ground.stone": "Stone Ores",
   "tag.item.c.ores_in_ground.deepslate": "Deepslate Ores",
   "tag.item.c.ores_in_ground.netherrack": "Netherrack Ores",
-  
+
   "tag.item.c.chest": "Chests",
   "tag.item.c.coal": "Coals",
   "tag.item.c.sand": "Sands",

--- a/xplat/src/main/resources/assets/emi/lang/en_us.json
+++ b/xplat/src/main/resources/assets/emi/lang/en_us.json
@@ -263,7 +263,7 @@
   "tooltip.emi.bom.mode.view": "§6Viewing§r recipe tree",
   "tooltip.emi.bom.mode.craft": "§6Crafting§r recipe tree\nProgress will be shown in recipe tree\n§bSynthetic favorites§r added to sidebar",
   "tooltip.emi.bom.help": "The recipe tree shows the process and base cost of a recipe\nThe display can be panned and zoomed\n\nLeft click a node to choose a recipe to assign to it\nHold §6[shift]§r to automatically pick based on your inventory\n\nRight click a recipe node to fold it temporarily\nHold §6[shift]§r to clear the recipe\n\nThe initial tree state is controlled by default recipes\nA button next to recipes can set default recipe preferences\n\nThe toggle by total cost can be used to help craft a recipe tree\nWhile crafting, materials that need to be collected will be displayed\n§bSynthetic favorites§r will be added to the favorites sidebar that\nwill show incomplete steps and can be used to craft",
-
+  
   "tooltip.emi.fluid_interaction.basalt.soul_soil": "Below lava",
   "tooltip.emi.fluid_interaction.basalt.blue_ice": "Adjacent to lava",
 
@@ -327,7 +327,7 @@
   "emi.category.emi.fuel": "Fuel",
   "emi.category.emi.composting": "Composting",
   "emi.category.emi.info": "Info",
-
+  
   "emi.category.emi.tag": "Tags",
   "emi.category.emi.ingredient": "Ingredients",
 
@@ -529,7 +529,7 @@
   "tag.item.c.ores_in_ground.stone": "Stone Ores",
   "tag.item.c.ores_in_ground.deepslate": "Deepslate Ores",
   "tag.item.c.ores_in_ground.netherrack": "Netherrack Ores",
-
+  
   "tag.item.c.chest": "Chests",
   "tag.item.c.coal": "Coals",
   "tag.item.c.sand": "Sands",


### PR DESCRIPTION
Taking notes from GTNH NEI, this PR adds a keybind that - when pressed while hovering over a bookmarked favorite - will automatically search the currently open inventory (chest, crate, barrel, etc) and pull that item into the players inventory, ready for crafting. Works well with synthetic favorites that have a count, which will pull exactly that amount, if available.

Leaving as a draft for now to gauge interest, as I will have to create a new registry for mods to handle their own special inventory containers (like AE2, that doesn't have real container slots, and will need compat added). I've created a quick mock of a new registry method and am testing AE2 side integration with it, would look like the below:

```java
public interface EmiRegistry {

...

	/**
	 * Adds an EmiStackPuller to screens of a given class.
	 * Stack pullers take items from the currently open container and place them in the players inventory.
	 */
	<T extends Screen> void addStackPuller(Class<T> clazz, EmiStackPuller<T> puller);

...

}
```

```java
public interface EmiStackPuller<T extends Screen> {

	/**
	 * Pull items onto the player cursor
	 */
	public void pullStackFromSlot(T screen, int slotId);

}
```

Video demonstration in Monifactory - Forge 1.20.1

https://github.com/user-attachments/assets/4de3b104-8097-4593-8c97-a19d5ee37132
