### PR TITLE
don't render amount text twice in recipe cost tooltip

### DIFF
--- a/xplat/src/main/java/dev/emi/emi/screen/tooltip/RecipeCostTooltipComponent.java
+++ b/xplat/src/main/java/dev/emi/emi/screen/tooltip/RecipeCostTooltipComponent.java
@@ -93,7 +93,7 @@ public class RecipeCostTooltipComponent implements EmiTooltipComponent {
 	@Override
 	public void drawTooltip(EmiDrawContext context, TooltipRenderData render) {
 		for (Node node : nodes) {
-			context.drawStack(node.stack, node.x, node.y);
+			context.drawStack(node.stack, node.x, node.y, ~EmiIngredient.RENDER_AMOUNT);
 			EmiRenderHelper.renderAmount(context, node.x, node.y, node.text);
 		}
 	}


### PR DESCRIPTION
fixes #1077 