### PR TITLE
Add sanity checks to prevent recipe fill from deleting items

### DIFF
--- a/xplat/src/main/java/dev/emi/emi/network/FillRecipeC2SPacket.java
+++ b/xplat/src/main/java/dev/emi/emi/network/FillRecipeC2SPacket.java
@@ -137,8 +137,8 @@ public class FillRecipeC2SPacket implements EmiPacket {
 					} else {
 						Slot s = crafting.get(i);
 						if (s != null && s.canInsert(stack) && stack.getCount() <= s.getMaxItemCount() && stack.getCount() <= stack.getMaxCount()) {
-							if(!s.getStack().isEmpty()) { // Make sure we don't accidentally delete any items that could have been placed in this slot
-								if(s.canTakeItems(player)) {
+							if (!s.getStack().isEmpty()) { // Make sure we don't accidentally delete any items that could have been placed in this slot
+								if (s.canTakeItems(player)) {
 									ItemStack taken = s.getStack();
 									rubble.add(taken.copy());
 									s.setStack(ItemStack.EMPTY);

--- a/xplat/src/main/java/dev/emi/emi/network/FillRecipeC2SPacket.java
+++ b/xplat/src/main/java/dev/emi/emi/network/FillRecipeC2SPacket.java
@@ -137,6 +137,17 @@ public class FillRecipeC2SPacket implements EmiPacket {
 					} else {
 						Slot s = crafting.get(i);
 						if (s != null && s.canInsert(stack) && stack.getCount() <= s.getMaxItemCount() && stack.getCount() <= stack.getMaxCount()) {
+							if(!s.getStack().isEmpty()) { // Make sure we don't accidentally delete any items that could have been placed in this slot
+								if(s.canTakeItems(player)) {
+									ItemStack taken = s.getStack();
+									rubble.add(taken.copy());
+									s.setStack(ItemStack.EMPTY);
+									s.onTakeItem(player, taken);
+								} else {
+									player.getInventory().offerOrDrop(stack);
+									continue;
+								}
+							}
 							s.setStack(stack);
 						} else {
 							player.getInventory().offerOrDrop(stack);


### PR DESCRIPTION
I wasn't sure if my explanation in #1124 pointed out which code needed changing well enough, so I thought I'd make a pull request since it's ultimately a really small change.

Ultimately, this PR boils down to one change:  
Right before recipe fill sets the item in a slot, make sure the slot is empty and try to empty it if it isn't.

I tried to avoid restructuring the code more than was absolutely necessary to add this check, so you may want to refactor it.