### PR TITLE
refactor(JemiDragDropHandler): 重构拖拽目标获取逻辑以支持多处理器

### DIFF
--- a/xplat/src/main/java/dev/emi/emi/jemi/runtime/JemiDragDropHandler.java
+++ b/xplat/src/main/java/dev/emi/emi/jemi/runtime/JemiDragDropHandler.java
@@ -3,6 +3,7 @@ package dev.emi.emi.jemi.runtime;
 import java.util.List;
 import java.util.Optional;
 
+import com.google.common.collect.Lists;
 import dev.emi.emi.api.EmiDragDropHandler;
 import dev.emi.emi.api.stack.EmiIngredient;
 import dev.emi.emi.jemi.JemiPlugin;
@@ -57,11 +58,10 @@ public class JemiDragDropHandler implements EmiDragDropHandler<Screen> {
 	}
 
 	private <I> List<IGhostIngredientHandler.Target<I>> getTargets(Screen screen, ITypedIngredient<I> typed) {
-		Optional<IGhostIngredientHandler<Screen>> optGhost = JemiPlugin.runtime.getScreenHelper().getGhostIngredientHandler(screen);
-		if (optGhost.isPresent()) {
-			IGhostIngredientHandler<Screen> ghost = optGhost.get();
-			return ghost.getTargetsTyped(screen, typed, false);
+		List<IGhostIngredientHandler.Target<I>> allTargets = Lists.newArrayList();
+		for (IGhostIngredientHandler<Screen> handler : JemiPlugin.runtime.getScreenHelper().getGhostIngredientHandlers(screen)) {
+			allTargets.addAll(handler.getTargetsTyped(screen, typed, false));
 		}
-		return List.of();
+		return allTargets;
 	}
 }


### PR DESCRIPTION
旧的 API 已经弃用，当遇到多个 Mod 对同一个界面注册多个 `GhostIngredientHandler` 时，会导致仅生效最新注册的。采用新的 API 来解决这个问题。