### PR TITLE
feat: add searchAdvancedTooltips config option

### DIFF
--- a/xplat/src/main/java/dev/emi/emi/api/stack/EmiStack.java
+++ b/xplat/src/main/java/dev/emi/emi/api/stack/EmiStack.java
@@ -130,6 +130,10 @@ public abstract class EmiStack implements EmiIngredient {
 
 	public abstract List<Text> getTooltipText();
 
+	public List<Text> getTooltipText(boolean advanced) {
+		return getTooltipText();
+	}
+
 	public List<TooltipComponent> getTooltip() {
 		List<TooltipComponent> list = Lists.newArrayList();
 		if (!getRemainder().isEmpty()) {

--- a/xplat/src/main/java/dev/emi/emi/api/stack/ItemEmiStack.java
+++ b/xplat/src/main/java/dev/emi/emi/api/stack/ItemEmiStack.java
@@ -15,6 +15,7 @@ import com.google.common.collect.Lists;
 import dev.emi.emi.EmiPort;
 import dev.emi.emi.EmiRenderHelper;
 import dev.emi.emi.api.render.EmiRender;
+import dev.emi.emi.config.EmiConfig;
 import dev.emi.emi.platform.EmiAgnos;
 import dev.emi.emi.runtime.EmiDrawContext;
 import dev.emi.emi.screen.StackBatcher.Batchable;
@@ -161,11 +162,17 @@ public class ItemEmiStack extends EmiStack implements Batchable {
 
 	@Override
 	public List<Text> getTooltipText() {
+		return getTooltipText(EmiConfig.searchAdvancedTooltips);
+	}
+
+	@Override
+	public List<Text> getTooltipText(boolean advanced) {
+		TooltipType type = advanced ? TooltipType.ADVANCED : TooltipType.BASIC;
 		if (client.isOnThread()) {
-			return getItemStack().getTooltip(Item.TooltipContext.create(client.world), client.player, TooltipType.BASIC);
+			return getItemStack().getTooltip(Item.TooltipContext.create(client.world), client.player, type);
 		} else {
 			// Don't provide world or entity as context, as they are not thread safe
-			return getItemStack().getTooltip(Item.TooltipContext.create(client.world.getRegistryManager()), null, TooltipType.BASIC);
+			return getItemStack().getTooltip(Item.TooltipContext.create(client.world.getRegistryManager()), null, type);
 		}
 	}
 

--- a/xplat/src/main/java/dev/emi/emi/config/EmiConfig.java
+++ b/xplat/src/main/java/dev/emi/emi/config/EmiConfig.java
@@ -78,6 +78,11 @@ public class EmiConfig {
 	@ConfigValue("general.search-tags-by-default")
 	public static boolean searchTagsByDefault = false;
 
+	@Comment("Whether tooltip search ($) should include advanced tooltip text " +
+		"(extra information visible with F3+H, such as registry names).")
+	@ConfigValue("general.search-advanced-tooltips")
+	public static boolean searchAdvancedTooltips = false;
+
 	// UI
 	@Comment("Which action should be performed when clicking the recipe book.")
 	@ConfigValue("ui.recipe-book-action")

--- a/xplat/src/main/java/dev/emi/emi/screen/ConfigScreen.java
+++ b/xplat/src/main/java/dev/emi/emi/screen/ConfigScreen.java
@@ -71,11 +71,13 @@ public class ConfigScreen extends Screen {
 	public int lastModifier;
 	public String originalConfig;
 	public ButtonWidget resetButton;
+	private boolean oldSearchAdvancedTooltips;
 
 	public ConfigScreen(Screen last) {
 		super(EmiPort.translatable("screen.emi.config"));
 		this.last = last;
 		originalConfig = EmiConfig.getSavedConfig();
+		oldSearchAdvancedTooltips = EmiConfig.searchAdvancedTooltips;
 	}
 
 	public void setActiveBind(EmiBind bind, int offset) {
@@ -88,6 +90,9 @@ public class ConfigScreen extends Screen {
 	@Override
 	public void close() {
 		EmiConfig.writeConfig();
+		if (EmiConfig.searchAdvancedTooltips != oldSearchAdvancedTooltips) {
+			EmiSearch.bake();
+		}
 		EmiSearch.update();
 		MinecraftClient.getInstance().setScreen(last);
 	}

--- a/xplat/src/main/java/dev/emi/emi/search/EmiSearch.java
+++ b/xplat/src/main/java/dev/emi/emi/search/EmiSearch.java
@@ -71,7 +71,7 @@ public class EmiSearch {
 				if (name != null) {
 					names.add(searchStack, name.getString().toLowerCase());
 				}
-				List<Text> tooltip = stack.getTooltipText();
+				List<Text> tooltip = stack.getTooltipText(EmiConfig.searchAdvancedTooltips);
 				if (tooltip != null) {
 					for (int i = 1; i < tooltip.size(); i++) {
 						Text text = tooltip.get(i);


### PR DESCRIPTION
Adds a configurable `searchAdvancedTooltips` option (default: false) that controls whether the `$` tooltip search indexes text from `TooltipType.ADVANCED` (extra information visible with F3+H, such as registry names and component counts).

Implements the equivalent of JEI's `searchAdvancedTooltips` feature for EMI.

## Changes
- **EmiConfig**: new `general.search-advanced-tooltips` boolean field
- **EmiStack**: add `getTooltipText(boolean)` default method
- **ItemEmiStack**: override for `TooltipType.ADVANCED`/`BASIC` branching
- **EmiSearch**: `bake()` passes config value to `getTooltipText()`
- **ConfigScreen**: trigger search index rebake when option is toggled

See the full design discussion and implementation details in the linked issue.

Closes #1167

> AI-generated disclosure: This contribution was created with the assistance of an AI language model (DeepSeek Pro via Hermes Agent).