### PR TITLE
feat(config, screen): add configurable display all recipes keybind

### DIFF
--- a/xplat/src/main/java/dev/emi/emi/config/EmiConfig.java
+++ b/xplat/src/main/java/dev/emi/emi/config/EmiConfig.java
@@ -363,6 +363,10 @@ public class EmiConfig {
 	@ConfigValue("binds.clear-search")
 	public static EmiBind clearSearch = new EmiBind("key.emi.clear_search", InputUtil.UNKNOWN_KEY.getCode());
 
+	@Comment("Display all recipes in the game.")
+	@ConfigValue("binds.display-all-recipes")
+	public static EmiBind displayAllRecipes = new EmiBind("key.emi.display_all_recipes", EmiInput.CONTROL_MASK, GLFW.GLFW_KEY_Y);
+
 	@Comment("Display the recipes for creating a stack.")
 	@ConfigValue("binds.view-recipes")
 	public static EmiBind viewRecipes = new EmiBind("key.emi.view_recipes",

--- a/xplat/src/main/java/dev/emi/emi/screen/EmiScreenManager.java
+++ b/xplat/src/main/java/dev/emi/emi/screen/EmiScreenManager.java
@@ -1132,7 +1132,7 @@ public class EmiScreenManager {
 				return true;
 			}
 		}
-		if (EmiInput.isControlDown() && keyCode == GLFW.GLFW_KEY_Y) {
+		if (EmiConfig.displayAllRecipes.matchesKey(keyCode, scanCode)) {
 			EmiApi.displayAllRecipes();
 			return true;
 		} else {

--- a/xplat/src/main/resources/assets/emi/lang/en_us.json
+++ b/xplat/src/main/resources/assets/emi/lang/en_us.json
@@ -6,6 +6,8 @@
   "key.emi.toggle_visibility": "Toggle Visibility",
   "key.emi.focus_search": "Focus Search",
   "key.emi.clear_search": "Clear Search",
+  "key.emi.display_all_recipes": "Display All Recipes",
+
   "key.emi.view_recipes": "View Recipes",
   "key.emi.view_uses": "View Uses",
   "key.emi.favorite": "Favorite",

--- a/xplat/src/main/resources/assets/emi/lang/zh_cn.json
+++ b/xplat/src/main/resources/assets/emi/lang/zh_cn.json
@@ -9,6 +9,9 @@
   "config.emi.tooltip.binds.focus_search": "聚焦至EMI搜索栏",
   "key.emi.clear_search": "清空搜索栏",
   "config.emi.tooltip.binds.clear_search": "清空EMI搜索栏",
+  "key.emi.display_all_recipes": "显示全部配方",
+  "config.emi.tooltip.binds.display_all_recipes": "显示游戏中所有可用的配方",
+
   "key.emi.view_recipes": "查看配方",
   "config.emi.tooltip.binds.view_recipes": "查看选中物品的配方",
   "key.emi.view_uses": "查看用途",


### PR DESCRIPTION
Replace hardcoded Ctrl+Y hotkey for display all recipes with a configurable keybind, add proper localization strings for en_us and zh_cn. 
Having tested the fabric version in my env and it works, but not other versions. Having add translations for en_us and zh_cn, but not other langs which are unfamiliar to me