### PR TITLE
fix(zh_cn): correct misleading translation for emi.reloading.worry

### DIFF
--- a/xplat/src/main/resources/assets/emi/lang/zh_cn.json
+++ b/xplat/src/main/resources/assets/emi/lang/zh_cn.json
@@ -299,7 +299,7 @@
   "emi.reloading": "EMI重载中...",
   "emi.reloading.waiting": "EMI正等待服务器发送配方信息...",
   "emi.reloading.error": "§cEMI重载时出现严重错误，请查看日志",
-  "emi.reloading.worry": "§c延迟较大，网络还正常吗？",
+  "emi.reloading.worry": "§c遇到延迟，一切都还顺利吗？",
   "emi.reloading.still_baking_recipes": "§d正在处理配方...",
   "emi.search": "搜索EMI...",
   "emi.search_config": "搜索设置项...",


### PR DESCRIPTION
The current simplified Chinese (`zh_cn`) translation for `"emi.reloading.worry"` is `"§c延迟较大，网络还正常吗？"`. 

This translation introduces the word **"网络" (network/internet)**, which is not present in the original English text (`"§cExperiencing delay, is everything alright?"`). This addition causes significant issues:
1. **Misleading for Single-player Mode:** The delay in recipe reloading or baking is often caused by heavy local computing (e.g., large modpacks) or local thread hanging, rather than internet connectivity. Single-player users seeing this message will be confused about why their internet is being questioned.
2. **Misguided Blame:** Narrowing down local freezing or optimization bottlenecks strictly to "network issues" can mislead the community and players into incorrectly blaming server connections or their own ISPs, rather than understanding it as a data-processing stage.

Compared to this, the traditional Chinese (`zh_tw`) translation (`"§c遇到延遲，一切都還順利嗎？"`) is much more accurate and generalized for both local and server contexts.

#### Solution
Directly converted the more accurate traditional Chinese (`zh_tw`) translation into simplified Chinese (`zh_cn`) to replace the current misleading text.

**Changes Made:**
* **From:** `"emi.reloading.worry": "§c延迟较大，网络还正常吗？",`
* **To:** `"emi.reloading.worry": "§c遇到延迟，一切都还顺利吗？",`

This ensures the warning message remains accurate, natural, and helpful regardless of whether the user is playing in single-player or multiplayer mode.