### PR TITLE
[1.21.1] Add compatibility with nbt/component driven recipes

### DIFF
--- a/xplat/src/main/java/dev/emi/emi/config/EmiConfig.java
+++ b/xplat/src/main/java/dev/emi/emi/config/EmiConfig.java
@@ -78,6 +78,10 @@ public class EmiConfig {
 	@ConfigValue("general.search-tags-by-default")
 	public static boolean searchTagsByDefault = false;
 
+	@Comment("When enabled, EMI's default stack comparison accounts for component data. This can improve recipe trees for recipes that use the same item with different components, but may make component-distinct stacks appear as separate entries. Requires a restart after being enabled.")
+	@ConfigValue("general.compare-components-by-default")
+	public static boolean compareComponentsByDefault = false;
+
 	// UI
 	@Comment("Which action should be performed when clicking the recipe book.")
 	@ConfigValue("ui.recipe-book-action")

--- a/xplat/src/main/java/dev/emi/emi/registry/EmiComparisonDefaults.java
+++ b/xplat/src/main/java/dev/emi/emi/registry/EmiComparisonDefaults.java
@@ -3,6 +3,7 @@ package dev.emi.emi.registry;
 import java.util.Map;
 
 import dev.emi.emi.api.stack.Comparison;
+import dev.emi.emi.config.EmiConfig;
 
 public class EmiComparisonDefaults {
 	public static Map<Object, Comparison> comparisons = Map.of();
@@ -10,6 +11,9 @@ public class EmiComparisonDefaults {
 	public static Comparison get(Object obj) {
 		if (comparisons.containsKey(obj)) {
 			return comparisons.get(obj);
+		}
+		if (EmiConfig.compareComponentsByDefault) {
+			return Comparison.compareComponents();
 		}
 		return Comparison.DEFAULT_COMPARISON;
 	}

--- a/xplat/src/main/resources/assets/emi/lang/en_us.json
+++ b/xplat/src/main/resources/assets/emi/lang/en_us.json
@@ -113,6 +113,8 @@
   "config.emi.general.search_tooltip_by_default": "Search Tooltip by Default",
   "config.emi.general.search_mod_name_by_default": "Search Mod Name by Default",
   "config.emi.general.search_tags_by_default": "Search Tags by Default",
+  "config.emi.general.compare_components_by_default": "Compare Components by Default",
+  "config.emi.tooltip.general.compare_components_by_default": "When enabled, EMI's default stack comparison accounts for component data. This can improve recipe trees for recipes that use the same item with different components, but may make component-distinct stacks appear as separate entries. Requires a restart after being changed.",
 
   "config.emi.ui.effect_location": "Effect Location",
   "config.emi.ui.center_search_bar": "Center Search Bar",


### PR DESCRIPTION
Add compatibility with nbt/component driven recipes, such has kubejs nbt driven recipe components.
Currently only has us localization.