### PR TITLE
Prevent null recipe categories from aborting reload

### DIFF
--- a/xplat/src/main/java/dev/emi/emi/registry/EmiRecipes.java
+++ b/xplat/src/main/java/dev/emi/emi/registry/EmiRecipes.java
@@ -88,6 +88,15 @@ public class EmiRecipes {
 		invalidators.addAll(EmiData.recipeFilters);
 
 		invalidators.add(r -> {
+			EmiRecipeCategory category = r.getCategory();
+			if (category == null) {
+				EmiReloadLog.warn("Recipe " + r.getId() + " from " + r.getClass().getName() + " has null category");
+				return true;
+			}
+			return false;
+		});
+
+		invalidators.add(r -> {
 			for (EmiIngredient i : Iterables.concat(r.getInputs(), r.getOutputs(), r.getCatalysts())) {
 				if (EmiHidden.isDisabled(i)) {
 					return true;


### PR DESCRIPTION

### Description

Third-party recipe implementations may return a null category, as seen in #1210. Currently, this causes EMI itself to throw a `NullPointerException` while reporting the unregistered category, aborting the entire recipe reload and making EMI unusable.

This change filters recipes with null categories before they are passed to the recipe manager. It also logs the recipe ID and implementation class, allowing the faulty integration to be identified without preventing the remaining recipes from loading.

This does not fix the underlying third-party integration issue, but prevents a single invalid recipe from aborting the entire EMI reload and provides enough information to diagnose its source.

### Testing

- Built the project successfully.
- Confirmed startup on Minecraft 1.21.1 with Fabric.
- Confirmed startup on Minecraft 1.21.1 with NeoForge.
- Tested the equivalent change against the failure reported in #1210 on MC 1.20.1 Forge.

  - 8 recipes with null categories were identified and filtered.
  - The offending recipe implementation was logged.
  - EMI completed recipe and search baking instead of aborting with a `NullPointerException`.